### PR TITLE
Fixes #30, using a slugger to create links

### DIFF
--- a/examples/docs/deepextending.schema.md
+++ b/examples/docs/deepextending.schema.md
@@ -26,11 +26,11 @@ This is an extending schema. It is extending another extending schema. It pulls 
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | [Definitions](definitions.schema.md#@id) |
+| [@id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
 | [bar](#bar) | `string` | Optional | [Extensible](extensible.schema.md#bar) |
 | [baz](#baz) | `string` | Optional | [Extending](extending.schema.md#baz) |
 | [hey](#hey) | `string` | Optional | Deeply Extending (this schema) |
-| [id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
+| [id](#id-1) | `string` | Optional | [Definitions](definitions.schema.md#id-1) |
 | [meta:id](#metaid) | `string` | Optional | [Definitions](definitions.schema.md#metaid) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
@@ -41,7 +41,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 `@id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#@id)
+* defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
@@ -136,7 +136,7 @@ A unique identifier given to every addressable thing.
 `id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+* defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
@@ -156,7 +156,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 `meta:id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#meta:id)
+* defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 

--- a/examples/docs/definitions.schema.md
+++ b/examples/docs/definitions.schema.md
@@ -36,8 +36,8 @@ aks.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | Definitions (this schema) |
-| [id](#id) | `string` | **Required** | Definitions (this schema) |
+| [@id](#id) | `string` | Optional | Definitions (this schema) |
+| [id](#id-1) | `string` | **Required** | Definitions (this schema) |
 | [meta:id](#metaid) | `string` | Optional | Definitions (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 

--- a/examples/docs/extending.schema.md
+++ b/examples/docs/extending.schema.md
@@ -25,10 +25,10 @@ This is an extending schema. It pulls `definitions` from other schemas.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | [Definitions](definitions.schema.md#@id) |
+| [@id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
 | [bar](#bar) | `string` | Optional | [Extensible](extensible.schema.md#bar) |
 | [baz](#baz) | `string` | Optional | Extending (this schema) |
-| [id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
+| [id](#id-1) | `string` | Optional | [Definitions](definitions.schema.md#id-1) |
 | [meta:id](#metaid) | `string` | Optional | [Definitions](definitions.schema.md#metaid) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
@@ -39,7 +39,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 `@id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#@id)
+* defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
@@ -115,7 +115,7 @@ A unique identifier given to every addressable thing.
 `id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+* defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
@@ -135,7 +135,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 `meta:id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#meta:id)
+* defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 

--- a/examples/docs/identifiable.schema.md
+++ b/examples/docs/identifiable.schema.md
@@ -19,7 +19,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | Identifiable (this schema) |
+| [@id](#id) | `string` | Optional | Identifiable (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
 ## @id

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -13,6 +13,17 @@ var ejs = require('ejs');
 const pejs = Promise.promisifyAll(ejs);
 var validUrl = require('valid-url');
 const { headers } = require('./header');
+var GithubSlugger = require('github-slugger');
+
+function createGithubSlugs(names){
+  var slugger = new GithubSlugger();
+  slugger.reset();
+  names = names.sort();
+  return names.reduce(function(result, item) {
+    result[item] = slugger.slug(item);
+    return result;
+  }, {});
+}
 
 function render([ template, context ]) {
   return pejs.renderFileAsync(template, context, { debug: false });
@@ -143,6 +154,7 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
 
   console.log(filename);
   //console.log(dependencyMap);
+  let propertiesSlugs = createGithubSlugs(_.keys(schema.properties));
 
   // this structure allows us to have separate templates for each element. Instead of having
   // one huge template, each block can be built individually
@@ -163,7 +175,8 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
       props: requiredProperties(schema.properties, schema.required),
       pprops: _.mapValues(schema.patternProperties, simpletype),
       title: schema.title,
-      additional: schema.additionalProperties
+      additional: schema.additionalProperties,
+      propertiesSlugs: propertiesSlugs
     } ]);
     //regular properties
     for (let i=0; i<_.keys(schema.properties).length;i++) {
@@ -173,7 +186,9 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
         required: schema.required ? schema.required.includes(name) : false,
         examples: stringifyExamples(schema.properties[name]['examples']),
         ejs: ejsRender,
-        schema: simpletype(schema.properties[name]) } ]);
+        schema: simpletype(schema.properties[name]),
+        nameSlug: propertiesSlugs[name]
+      } ]);
     }
     //patterns properties
     for (let i=0; i<_.keys(schema.patternProperties).length;i++) {
@@ -202,12 +217,15 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
         }
       }
     }
+    propertiesSlugs = createGithubSlugs(_.keys(abstract));
     if (_.keys(abstract).length>0) {
       //console.log('I got definitions!', abstract);
       multi.push([ 'definitions.ejs', {
         props: requiredProperties(abstract),
         title: schema.title,
-        id: schema.$id } ]);
+        id: schema.$id,
+        propertiesSlugs:propertiesSlugs
+      } ]);
       for (let i=0; i<_.keys(abstract).length;i++) {
         const name = _.keys(abstract).sort()[i];
         multi.push( [ 'property.ejs', {
@@ -215,7 +233,9 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
           required: false,
           ejs: ejsRender,
           examples: stringifyExamples(abstract[name]['examples']),
-          schema: simpletype(abstract[name]) } ]);
+          schema: simpletype(abstract[name]),
+          nameSlug: propertiesSlugs[name]
+        } ]);
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "async": "^2.0.1",
     "bluebird": "^3.5.1",
     "ejs": "^2.4.2",
+    "github-slugger": "^1.2.0",
     "json-pointer": "^0.6.0",
     "lodash": "^4.5.0",
     "mkdirp": "^0.5.1",

--- a/spec/examples/deepextending.schema.md
+++ b/spec/examples/deepextending.schema.md
@@ -26,11 +26,11 @@ This is an extending schema. It is extending another extending schema. It pulls 
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | [Definitions](definitions.schema.md#@id) |
+| [@id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
 | [bar](#bar) | `string` | Optional | [Extensible](extensible.schema.md#bar) |
 | [baz](#baz) | `string` | Optional | [Extending](extending.schema.md#baz) |
 | [hey](#hey) | `string` | Optional | Deeply Extending (this schema) |
-| [id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
+| [id](#id-1) | `string` | Optional | [Definitions](definitions.schema.md#id-1) |
 | [meta:id](#metaid) | `string` | Optional | [Definitions](definitions.schema.md#metaid) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
@@ -41,7 +41,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 `@id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#@id)
+* defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
@@ -136,7 +136,7 @@ A unique identifier given to every addressable thing.
 `id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+* defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
@@ -156,7 +156,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 `meta:id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#meta:id)
+* defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 

--- a/spec/examples/definitions.schema.md
+++ b/spec/examples/definitions.schema.md
@@ -36,8 +36,8 @@ aks.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | Definitions (this schema) |
-| [id](#id) | `string` | **Required** | Definitions (this schema) |
+| [@id](#id) | `string` | Optional | Definitions (this schema) |
+| [id](#id-1) | `string` | **Required** | Definitions (this schema) |
 | [meta:id](#metaid) | `string` | Optional | Definitions (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 

--- a/spec/examples/extending.schema.md
+++ b/spec/examples/extending.schema.md
@@ -25,10 +25,10 @@ This is an extending schema. It pulls `definitions` from other schemas.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | [Definitions](definitions.schema.md#@id) |
+| [@id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
 | [bar](#bar) | `string` | Optional | [Extensible](extensible.schema.md#bar) |
 | [baz](#baz) | `string` | Optional | Extending (this schema) |
-| [id](#id) | `string` | Optional | [Definitions](definitions.schema.md#id) |
+| [id](#id-1) | `string` | Optional | [Definitions](definitions.schema.md#id-1) |
 | [meta:id](#metaid) | `string` | Optional | [Definitions](definitions.schema.md#metaid) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
@@ -39,7 +39,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 `@id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#@id)
+* defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
@@ -115,7 +115,7 @@ A unique identifier given to every addressable thing.
 `id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+* defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
@@ -135,7 +135,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 `meta:id`
 * is optional
 * type: `string`
-* defined in [Definitions](definitions.schema.md#meta:id)
+* defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 

--- a/spec/examples/identifiable.schema.md
+++ b/spec/examples/identifiable.schema.md
@@ -19,7 +19,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
-| [@id](#@id) | `string` | Optional | Identifiable (this schema) |
+| [@id](#id) | `string` | Optional | Identifiable (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
 ## @id

--- a/spec/lib/integrationTest.spec.js
+++ b/spec/lib/integrationTest.spec.js
@@ -52,14 +52,13 @@ describe('Compare results', () => {
     ]);
     ls.on('close', code => {
       expect(code).toEqual(0);
-
-      const files = readdirSync('./spec/examples');
+      const files = readdirSync('./spec/examples').filter(item => !(/(^|\/)\.[^\/\.]/g).test(item));
       expect(files.length).toEqual(18);
       done();
     });
   });
 
-  const files = readdirSync('./spec/examples');
+  const files = readdirSync('./spec/examples').filter(item => !(/(^|\/)\.[^\/\.]/g).test(item));
   files.forEach(file => {
     if (statSync('./spec/examples/' + file).isFile()) {
       it('Comparing ' + file, indone => {

--- a/templates/md/definitions.ejs
+++ b/templates/md/definitions.ejs
@@ -12,5 +12,5 @@
 |----------|------|-------|
 <% _.keys(props).sort().forEach(property => {
   const schema = props[property]; %>
-| [<%= property %>](#<%= property.replace(':', '').toLowerCase() %>) | <%= schema.simpletype %> | `<%= id%>#/definitions/<%= schema.definitiongroup %>` |
+| [<%= property %>](#<%= propertiesSlugs[property] %>) | <%= schema.simpletype %> | `<%= id%>#/definitions/<%= schema.definitiongroup %>` |
 <% }); %>

--- a/templates/md/nested-property.ejs
+++ b/templates/md/nested-property.ejs
@@ -29,7 +29,7 @@ The value of this property **must** be equal to:
 ```
 
 <% } else if (schema.enum!==undefined) { %>
-The value of this property **must** be equal to one of the [known values below](#<%=name %>-known-values).
+The value of this property **must** be equal to one of the [known values below](#<%=nameSlug %>-known-values).
 <% } else { %>
 
 ##### <%=name %> Type

--- a/templates/md/object-type.ejs
+++ b/templates/md/object-type.ejs
@@ -20,7 +20,8 @@
     name: property, 
     schema: inner,
     required: required,
-    examples: inner.examples
+    examples: inner.examples,
+    nameSlug:nameSlug
   }) %>
 
 <%

--- a/templates/md/properties.ejs
+++ b/templates/md/properties.ejs
@@ -11,9 +11,9 @@
 |----------|------|----------|------------|
 <% _.keys(props).sort().forEach(property => {
   const schema = props[property]; %>
-| [<%= property %>](#<%= property.replace(':', '').toLowerCase() %>) | <%= schema.simpletype %> | <%= schema.isrequired === true ? "**Required**" : "Optional" %> | <% 
+| [<%= property %>](#<%= propertiesSlugs[property] %>) | <%= schema.simpletype %> | <%= schema.isrequired === true ? "**Required**" : "Optional" %> | <% 
     if (schema.$oSchema) { 
-      %>[<%= schema.$oSchema.$linkVal %>](<%= schema.$oSchema.$linkPath %>#<%= property.replace(':', '').toLowerCase() %>)<% 
+      %>[<%= schema.$oSchema.$linkVal %>](<%= schema.$oSchema.$linkPath %>#<%= propertiesSlugs[property] %>)<% 
     } else { 
       %><%= title %> (this schema)<% } %> |
 <%

--- a/templates/md/property.ejs
+++ b/templates/md/property.ejs
@@ -19,7 +19,7 @@
 else if (schema.maxItems!==undefined                             ) { %>* no more than `<%=schema.maxItems %>` items in the array<% }
 else if (schema.minItems!==undefined                             ) { %>* at least `<%=schema.minItems %>` items in the array<% } %>
 <% } %>
-* defined in <% if (schema.$oSchema) { %>[<%= schema.$oSchema.$linkVal %>](<%= schema.$oSchema.$linkPath %>#<%= name %>)<% } else { %>this schema<% } %>
+* defined in <% if (schema.$oSchema) { %>[<%= schema.$oSchema.$linkVal %>](<%= schema.$oSchema.$linkPath %>#<%= nameSlug %>)<% } else { %>this schema<% } %>
 
 <% if (schema.const!==undefined) { %>
 The value of this property **must** be equal to:
@@ -30,7 +30,7 @@ The value of this property **must** be equal to:
 ```
 
 <% } else if (schema.enum!==undefined) { %>
-The value of this property **must** be equal to one of the [known values below](#<%=name %>-known-values).
+The value of this property **must** be equal to one of the [known values below](#<%=nameSlug %>-known-values).
 <% } else { %>
 
 ### <%=name %> Type
@@ -42,7 +42,7 @@ The value of this property **must** be equal to one of the [known values below](
 <% } else if (schema.type==="boolean") { %>
 <%- include("boolean-type",{schema:schema,_:_}) %>
 <% } else if (schema.type==="object") { %>
-<%- include("object-type",{schema:schema,_:_}) %>
+<%- include("object-type",{schema:schema,_:_,nameSlug:nameSlug}) %>
 <% } else if (schema.type==="array") { %>
 <%- include("array-type",{schema:schema,_:_,nested:false,ejs:ejs}) %>
 <% } else if (schema.$ref!==undefined) { %>


### PR DESCRIPTION
This will create correct links as github creates them, so as to navigate among schemas and properties. Used github-slugger module to generate slugs as github would generate for headings in markdown. 
