### PR TITLE
provide simpletype to ejs templates for reuse at nested props

### DIFF
--- a/examples/docs/complex.schema.md
+++ b/examples/docs/complex.schema.md
@@ -150,7 +150,7 @@ This is not foo.
 
 `nonfoo`
 * is optional
-* type: `boolean`
+* type: `const`
 
 The value of this property **must** be equal to:
 

--- a/examples/docs/enums.schema.md
+++ b/examples/docs/enums.schema.md
@@ -20,6 +20,7 @@ This is an example schema with examples for properties with enum values
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
 | [hello](#hello) | `enum` | **Required** | Enumerated  (this schema) |
+| [nested](#nested) | `object` | Optional | Enumerated  (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
 ## hello
@@ -38,6 +39,53 @@ The value of this property **must** be equal to one of the [known values below](
 |-------|-------------|
 | `World` |  |
 | `Welt` |  |
+
+
+
+
+## nested
+### Enumerated (Nested)
+
+This is an example schema with examples for properties of nested objects with enum values
+
+`nested`
+* is optional
+* type: `object`
+* defined in this schema
+
+### nested Type
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `test`| string | Optional |
+
+
+
+#### test
+
+A simple string. Pick a value.
+
+`test`
+* is optional
+* type: `enum`
+
+The value of this property **must** be equal to one of the [known values below](#nested-known-values).
+
+##### test Known Values
+| Value | Description |
+|-------|-------------|
+| `nested` |  |
+| `object` |  |
+| `works` |  |
+
+
+
+
+
 
 
 

--- a/examples/generated-schemas/enums.schema.json
+++ b/examples/generated-schemas/enums.schema.json
@@ -18,6 +18,22 @@
                 "Welt"
             ],
             "description": "A simple string. Pick a value."
+        },
+        "nested": {
+            "title": "Enumerated (Nested)",
+            "description": "This is an example schema with examples for properties of nested objects with enum values",
+            "type": "object",
+            "properties": {
+                "test": {
+                    "type": "string",
+                    "enum": [
+                        "nested",
+                        "object",
+                        "works"
+                    ],
+                    "description": "A simple string. Pick a value."
+                }
+            }
         }
     },
     "required": [

--- a/examples/schemas/enums.schema.json
+++ b/examples/schemas/enums.schema.json
@@ -15,6 +15,19 @@
       "type": "string",
       "enum": ["World", "Welt"],
       "description": "A simple string. Pick a value."
+    },
+
+    "nested": {
+      "title": "Enumerated (Nested)",
+      "description": "This is an example schema with examples for properties of nested objects with enum values",
+      "type": "object",
+      "properties": {
+        "test": {
+          "type": "string",
+          "enum": ["nested", "object", "works"],
+          "description": "A simple string. Pick a value."
+        }
+      }
     }
   },
   "required": [

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -243,7 +243,7 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
   multi = multi.map(([ template, context ]) => {
     return [
       path.join(__dirname, '../templates/md/' + template),
-      assoc(context, '_', _)
+      assoc(assoc(context, '_', _), 'simpletype', simpletype)
     ];
   });
 

--- a/spec/examples/complex.schema.md
+++ b/spec/examples/complex.schema.md
@@ -150,7 +150,7 @@ This is not foo.
 
 `nonfoo`
 * is optional
-* type: `boolean`
+* type: `const`
 
 The value of this property **must** be equal to:
 

--- a/spec/examples/enums.schema.md
+++ b/spec/examples/enums.schema.md
@@ -20,6 +20,7 @@ This is an example schema with examples for properties with enum values
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
 | [hello](#hello) | `enum` | **Required** | Enumerated  (this schema) |
+| [nested](#nested) | `object` | Optional | Enumerated  (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
 
 ## hello
@@ -38,6 +39,53 @@ The value of this property **must** be equal to one of the [known values below](
 |-------|-------------|
 | `World` |  |
 | `Welt` |  |
+
+
+
+
+## nested
+### Enumerated (Nested)
+
+This is an example schema with examples for properties of nested objects with enum values
+
+`nested`
+* is optional
+* type: `object`
+* defined in this schema
+
+### nested Type
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `test`| string | Optional |
+
+
+
+#### test
+
+A simple string. Pick a value.
+
+`test`
+* is optional
+* type: `enum`
+
+The value of this property **must** be equal to one of the [known values below](#nested-known-values).
+
+##### test Known Values
+| Value | Description |
+|-------|-------------|
+| `nested` |  |
+| `object` |  |
+| `works` |  |
+
+
+
+
+
 
 
 

--- a/templates/md/object-type.ejs
+++ b/templates/md/object-type.ejs
@@ -11,7 +11,7 @@
 
 <% _.keys(schema.properties).sort().forEach(property => {
   const inner = schema.properties[property];
-  inner.simpletype = "`" + inner.type + "`";
+  simpletype(inner)
   const required = (Array.isArray(schema.required)&&schema.required.indexOf(property)>=0); %>
 
 <%- include("nested-property",{


### PR DESCRIPTION
Thanks for this nice doc generator.
This fixes #69 `enum`'s within nested properties don't get displayed.