### PR TITLE
Newlines around lists

### DIFF
--- a/examples/docs/abstract.schema.md
+++ b/examples/docs/abstract.schema.md
@@ -28,6 +28,7 @@ This is an abstract schema. It has `definitions`, but does not declare any prope
 A unique identifier given to every addressable thing.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -42,11 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## foo
 
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -61,11 +64,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## nonfoo
 
 This is not foo.
 
 `nonfoo`
+
 * is optional
 * type: `const`
 * defined in this schema

--- a/examples/docs/arrays.schema.md
+++ b/examples/docs/arrays.schema.md
@@ -34,6 +34,7 @@ This is an example schema with examples for multiple array types and their const
 This is an array
 
 `boollist`
+
 * is optional
 * type: `boolean[]`
 * at least `1` items in the array
@@ -58,6 +59,7 @@ All items must be of the type:
 This is an array of coordinates in three-dimensional space.
 
 `coordinatelist`
+
 * is optional
 * type: `number[][]` (nested array)
 * no more than `10` items in the array
@@ -72,6 +74,7 @@ Nested array type: `number[]`
 
 All items must be of the type:
 `number`
+
 * minimum value: `0`
 * maximum value: `10`
 
@@ -92,6 +95,7 @@ A coordinate, specified by `x`, `y`, and `z` values
 This is an array
 
 `intlist`
+
 * is optional
 * type: `integer[]`
 * between `1` and `10` items in the array
@@ -113,14 +117,15 @@ All items must be of the type:
 
 
 
+
 ## list
 
 This is an array
 
 `list`
+
 * is optional
 * type: `string[]`
-
 * defined in this schema
 
 ### list Type
@@ -139,14 +144,15 @@ All items must be of the type:
 
 
 
+
 ## listlist
 
 This is an array of arrays
 
 `listlist`
+
 * is optional
 * type: `array[]` (nested array)
-
 * defined in this schema
 
 ### listlist Type
@@ -168,6 +174,7 @@ Nested array type: `array`
 This is an array
 
 `numlist`
+
 * is optional
 * type: `number[]`
 * no more than `10` items in the array
@@ -180,6 +187,7 @@ Array type: `number[]`
 
 All items must be of the type:
 `number`
+
 * minimum value: `10`
 
 
@@ -194,9 +202,9 @@ All items must be of the type:
 An array of simple objects
 
 `objectlist`
+
 * is optional
 * type: `object[]`
-
 * defined in this schema
 
 ### objectlist Type
@@ -220,6 +228,7 @@ All items must be of the type:
 The a property
 
 `a`
+
 * is **required**
 * type: `string`
 
@@ -235,11 +244,13 @@ The a property
 
 
 
+
 #### b
 
 The b property
 
 `b`
+
 * is optional
 * type: `integer`
 
@@ -261,14 +272,15 @@ The b property
 
 
 
+
 ## stringlistlist
 
 This is an array of arrays of strings
 
 `stringlistlist`
+
 * is optional
 * type: `string[][]` (nested array)
-
 * defined in this schema
 
 ### stringlistlist Type
@@ -280,6 +292,7 @@ Nested array type: `string[]`
 
 All items must be of the type:
 `string`
+
 
 
 

--- a/examples/docs/complex.schema.md
+++ b/examples/docs/complex.schema.md
@@ -40,6 +40,7 @@ This is an example schema that uses types defined in other schemas.
 Number in a range
 
 `and`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -54,6 +55,7 @@ Number in a range
 
 
 `number`
+
 * maximum value: `10`
 
 
@@ -61,6 +63,7 @@ Number in a range
 
 
 `number`
+
 * minimum value: `0`
 
 
@@ -74,6 +77,7 @@ Number in a range
 String or number…
 
 `or`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -91,10 +95,12 @@ String or number…
 
 
 
+
 #### Option 2
 
 
 `number`
+
 * minimum value: `0`
 
 
@@ -107,6 +113,7 @@ String or number…
 
 
 `refabstract`
+
 * is **required**
 * type: `object`
 * defined in this schema
@@ -129,6 +136,7 @@ String or number…
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 
@@ -144,11 +152,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 #### nonfoo
 
 This is not foo.
 
 `nonfoo`
+
 * is optional
 * type: `const`
 
@@ -171,9 +181,9 @@ false
 
 
 `reflist`
+
 * is optional
 * type: Simple
-
 * defined in this schema
 
 ### reflist Type
@@ -195,6 +205,7 @@ All items must be of the type:
 
 
 `refnamed`
+
 * is optional
 * type: Simple
 * defined in this schema
@@ -213,6 +224,7 @@ All items must be of the type:
 Exclusive choice.
 
 `xor`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -227,6 +239,7 @@ Exclusive choice.
 
 
 `number`
+
 * maximum value: `0`
 
 
@@ -234,6 +247,7 @@ Exclusive choice.
 
 
 `number`
+
 * minimum value: `10`
 
 
@@ -247,6 +261,7 @@ Applies to all properties that match the regular expression `int.*`
 
 
 `int.*`
+
 * is a property pattern
 * type: `integer`
 * defined in this schema
@@ -261,11 +276,13 @@ Applies to all properties that match the regular expression `int.*`
 
 
 
+
 ## Pattern: `str.*`
 Applies to all properties that match the regular expression `str.*`
 
 
 `str.*`
+
 * is a property pattern
 * type: `string`
 * defined in this schema
@@ -274,6 +291,7 @@ Applies to all properties that match the regular expression `str.*`
 
 
 `string`
+
 
 
 

--- a/examples/docs/constants.schema.md
+++ b/examples/docs/constants.schema.md
@@ -27,6 +27,7 @@ This is an example schema with examples for properties with constant values
 A simple string, without strong constraints.
 
 `hello`
+
 * is **required**
 * type: `const`
 * defined in this schema

--- a/examples/docs/custom.schema.md
+++ b/examples/docs/custom.schema.md
@@ -28,6 +28,7 @@ This is an extensible schema. It has `definitions`, that can be used in other sc
 A unique identifier given to every addressable thing.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -42,11 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## foo
 
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -55,6 +58,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 
 
 

--- a/examples/docs/deepextending.schema.md
+++ b/examples/docs/deepextending.schema.md
@@ -39,6 +39,7 @@ This is an extending schema. It is extending another extending schema. It pulls 
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id)
@@ -47,6 +48,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -59,6 +61,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in [Extensible](extensible.schema.md#bar)
@@ -67,6 +70,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -90,6 +94,7 @@ A horse walks into it.
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
+
 * is optional
 * type: `string`
 * defined in [Extending](extending.schema.md#baz)
@@ -98,6 +103,7 @@ This property has a unique name to demonstrate it's uniqueness.
 
 
 `string`
+
 
 
 
@@ -115,6 +121,7 @@ This property has a unique name to demonstrate it's uniqueness.
 A unique identifier given to every addressable thing.
 
 `hey`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -129,11 +136,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## id
 
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id-1)
@@ -142,6 +151,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -154,6 +164,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#metaid)
@@ -162,6 +173,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/examples/docs/definitions.schema.md
+++ b/examples/docs/definitions.schema.md
@@ -46,6 +46,7 @@ aks.
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -54,6 +55,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -66,6 +68,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is **required**
 * type: `string`
 * defined in this schema
@@ -74,6 +77,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -86,6 +90,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -94,6 +99,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/examples/docs/enums.schema.md
+++ b/examples/docs/enums.schema.md
@@ -28,6 +28,7 @@ This is an example schema with examples for properties with enum values
 A simple string. Pick a value.
 
 `hello`
+
 * is **required**
 * type: `enum`
 * defined in this schema
@@ -49,6 +50,7 @@ The value of this property **must** be equal to one of the [known values below](
 This is an example schema with examples for properties of nested objects with enum values
 
 `nested`
+
 * is optional
 * type: `object`
 * defined in this schema
@@ -70,6 +72,7 @@ This is an example schema with examples for properties of nested objects with en
 A simple string. Pick a value.
 
 `test`
+
 * is optional
 * type: `enum`
 

--- a/examples/docs/example.schema.md
+++ b/examples/docs/example.schema.md
@@ -36,6 +36,7 @@ This is an example schema with examples. Too many examples? There can never be t
 A simple string.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -44,6 +45,7 @@ A simple string.
 
 
 `string`
+
 
 
 
@@ -66,6 +68,7 @@ A simple string.
 A simple string.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -74,6 +77,7 @@ A simple string.
 
 
 `string`
+
 
 
 

--- a/examples/docs/examples.schema.md
+++ b/examples/docs/examples.schema.md
@@ -45,6 +45,7 @@ This is an example schema with *multiple* examples. Too many examples? There can
 A simple string.
 
 `bar`
+
 * is **required**
 * type: `string`
 * defined in this schema
@@ -53,6 +54,7 @@ A simple string.
 
 
 `string`
+
 
 
 
@@ -75,6 +77,7 @@ A simple string.
 A simple string.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -83,6 +86,7 @@ A simple string.
 
 
 `string`
+
 
 
 

--- a/examples/docs/extending.schema.md
+++ b/examples/docs/extending.schema.md
@@ -37,6 +37,7 @@ This is an extending schema. It pulls `definitions` from other schemas.
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id)
@@ -45,6 +46,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -57,6 +59,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in [Extensible](extensible.schema.md#bar)
@@ -65,6 +68,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -88,6 +92,7 @@ A horse walks into it.
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -96,6 +101,7 @@ This property has a unique name to demonstrate it's uniqueness.
 
 
 `string`
+
 
 
 
@@ -113,6 +119,7 @@ This property has a unique name to demonstrate it's uniqueness.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id-1)
@@ -121,6 +128,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -133,6 +141,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#metaid)
@@ -141,6 +150,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/examples/docs/extensible.schema.md
+++ b/examples/docs/extensible.schema.md
@@ -27,6 +27,7 @@ This is an extensible schema. It has `definitions`, that can be used in other sc
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -57,6 +59,7 @@ A horse walks into it.
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -65,6 +68,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 
 
 

--- a/examples/docs/identifiable.schema.md
+++ b/examples/docs/identifiable.schema.md
@@ -27,6 +27,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 A unique identifier given to every addressable thing.
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/examples/docs/simple.schema.md
+++ b/examples/docs/simple.schema.md
@@ -27,6 +27,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/examples/docs/simpletypes.schema.md
+++ b/examples/docs/simpletypes.schema.md
@@ -43,6 +43,7 @@ This is an example schema with examples for multiple types and their constraints
 Guess what number is valid
 
 `integer_threes`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -51,6 +52,7 @@ Guess what number is valid
 
 
 `integer`
+
 * minimum value: `2`
 * maximum value: `4`
 * must be a multiple of `3`
@@ -64,6 +66,7 @@ Guess what number is valid
 Just a whole number. I don't like fractions. Don't get too small
 
 `interger_constrained`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -72,6 +75,7 @@ Just a whole number. I don't like fractions. Don't get too small
 
 
 `integer`
+
 * minimum value: `10`
 
 
@@ -84,6 +88,7 @@ Just a whole number. I don't like fractions. Don't get too small
 Just a whole number. I don't like fractions.
 
 `interger_unconstrained`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -98,11 +103,13 @@ Just a whole number. I don't like fractions.
 
 
 
+
 ## number_constrained
 
 Just a number. Don't get too big.
 
 `number_constrained`
+
 * is optional
 * type: `number`
 * defined in this schema
@@ -111,6 +118,7 @@ Just a number. Don't get too big.
 
 
 `number`
+
 * value must not be greater or equal than: `10`
 
 
@@ -122,6 +130,7 @@ Just a number. Don't get too big.
 Just a number
 
 `number_unconstrained`
+
 * is optional
 * type: `number`
 * defined in this schema
@@ -136,11 +145,13 @@ Just a number
 
 
 
+
 ## string_date
 
 A date-like string.
 
 `string_date`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -149,6 +160,7 @@ A date-like string.
 
 
 `string`
+
 * format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
@@ -161,6 +173,7 @@ A date-like string.
 An email-like string.
 
 `string_email`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -169,6 +182,7 @@ An email-like string.
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 
@@ -181,6 +195,7 @@ An email-like string.
 A hostname-like string.
 
 `string_hostname`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -189,6 +204,7 @@ A hostname-like string.
 
 
 `string`
+
 * format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
 
 
@@ -201,6 +217,7 @@ A hostname-like string.
 An IPv4-like string.
 
 `string_ipv4`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -209,6 +226,7 @@ An IPv4-like string.
 
 
 `string`
+
 * format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
 
 
@@ -221,6 +239,7 @@ An IPv4-like string.
 An IPv6-like string.
 
 `string_ipv6`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -229,6 +248,7 @@ An IPv6-like string.
 
 
 `string`
+
 * format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
 
 
@@ -241,6 +261,7 @@ An IPv6-like string.
 A string with minumum and maximum length
 
 `string_length`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -249,6 +270,7 @@ A string with minumum and maximum length
 
 
 `string`
+
 * minimum length: 3 characters
 * maximum length: 3 characters
 
@@ -271,6 +293,7 @@ A string with minumum and maximum length
 A string following a regular expression
 
 `string_pattern`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -279,6 +302,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -328,6 +352,7 @@ All instances must conform to this regular expression
 A string following a regular expression
 
 `string_pattern_noexample`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -336,6 +361,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -354,6 +380,7 @@ All instances must conform to this regular expression
 A string following a regular expression
 
 `string_pattern_singleexample`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -362,6 +389,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -386,6 +414,7 @@ All instances must conform to this regular expression
 A simple string, without any constraints.
 
 `string_unconstrained`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -394,6 +423,7 @@ A simple string, without any constraints.
 
 
 `string`
+
 
 
 
@@ -411,6 +441,7 @@ A simple string, without any constraints.
 A URI.
 
 `string_uri`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -419,6 +450,7 @@ A URI.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -430,6 +462,7 @@ A URI.
 
 
 `yesno`
+
 * is **required**
 * type: `boolean`
 * defined in this schema

--- a/examples/docs/stabilizing.schema.md
+++ b/examples/docs/stabilizing.schema.md
@@ -27,6 +27,7 @@ This is a schema which is currently in the `stabilizing` status.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/examples/docs/subdir/subdir.schema.md
+++ b/examples/docs/subdir/subdir.schema.md
@@ -26,6 +26,7 @@ A schema in a sub directory
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -34,6 +35,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/spec/examples/abstract.schema.md
+++ b/spec/examples/abstract.schema.md
@@ -28,6 +28,7 @@ This is an abstract schema. It has `definitions`, but does not declare any prope
 A unique identifier given to every addressable thing.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -42,11 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## foo
 
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -61,11 +64,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## nonfoo
 
 This is not foo.
 
 `nonfoo`
+
 * is optional
 * type: `const`
 * defined in this schema

--- a/spec/examples/arrays.schema.md
+++ b/spec/examples/arrays.schema.md
@@ -34,6 +34,7 @@ This is an example schema with examples for multiple array types and their const
 This is an array
 
 `boollist`
+
 * is optional
 * type: `boolean[]`
 * at least `1` items in the array
@@ -58,6 +59,7 @@ All items must be of the type:
 This is an array of coordinates in three-dimensional space.
 
 `coordinatelist`
+
 * is optional
 * type: `number[][]` (nested array)
 * no more than `10` items in the array
@@ -72,6 +74,7 @@ Nested array type: `number[]`
 
 All items must be of the type:
 `number`
+
 * minimum value: `0`
 * maximum value: `10`
 
@@ -92,6 +95,7 @@ A coordinate, specified by `x`, `y`, and `z` values
 This is an array
 
 `intlist`
+
 * is optional
 * type: `integer[]`
 * between `1` and `10` items in the array
@@ -113,14 +117,15 @@ All items must be of the type:
 
 
 
+
 ## list
 
 This is an array
 
 `list`
+
 * is optional
 * type: `string[]`
-
 * defined in this schema
 
 ### list Type
@@ -139,14 +144,15 @@ All items must be of the type:
 
 
 
+
 ## listlist
 
 This is an array of arrays
 
 `listlist`
+
 * is optional
 * type: `array[]` (nested array)
-
 * defined in this schema
 
 ### listlist Type
@@ -168,6 +174,7 @@ Nested array type: `array`
 This is an array
 
 `numlist`
+
 * is optional
 * type: `number[]`
 * no more than `10` items in the array
@@ -180,6 +187,7 @@ Array type: `number[]`
 
 All items must be of the type:
 `number`
+
 * minimum value: `10`
 
 
@@ -194,9 +202,9 @@ All items must be of the type:
 An array of simple objects
 
 `objectlist`
+
 * is optional
 * type: `object[]`
-
 * defined in this schema
 
 ### objectlist Type
@@ -220,6 +228,7 @@ All items must be of the type:
 The a property
 
 `a`
+
 * is **required**
 * type: `string`
 
@@ -235,11 +244,13 @@ The a property
 
 
 
+
 #### b
 
 The b property
 
 `b`
+
 * is optional
 * type: `integer`
 
@@ -261,14 +272,15 @@ The b property
 
 
 
+
 ## stringlistlist
 
 This is an array of arrays of strings
 
 `stringlistlist`
+
 * is optional
 * type: `string[][]` (nested array)
-
 * defined in this schema
 
 ### stringlistlist Type
@@ -280,6 +292,7 @@ Nested array type: `string[]`
 
 All items must be of the type:
 `string`
+
 
 
 

--- a/spec/examples/complex.schema.md
+++ b/spec/examples/complex.schema.md
@@ -40,6 +40,7 @@ This is an example schema that uses types defined in other schemas.
 Number in a range
 
 `and`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -54,6 +55,7 @@ Number in a range
 
 
 `number`
+
 * maximum value: `10`
 
 
@@ -61,6 +63,7 @@ Number in a range
 
 
 `number`
+
 * minimum value: `0`
 
 
@@ -74,6 +77,7 @@ Number in a range
 String or number…
 
 `or`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -91,10 +95,12 @@ String or number…
 
 
 
+
 #### Option 2
 
 
 `number`
+
 * minimum value: `0`
 
 
@@ -107,6 +113,7 @@ String or number…
 
 
 `refabstract`
+
 * is **required**
 * type: `object`
 * defined in this schema
@@ -129,6 +136,7 @@ String or number…
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 
@@ -144,11 +152,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 #### nonfoo
 
 This is not foo.
 
 `nonfoo`
+
 * is optional
 * type: `const`
 
@@ -171,9 +181,9 @@ false
 
 
 `reflist`
+
 * is optional
 * type: Simple
-
 * defined in this schema
 
 ### reflist Type
@@ -195,6 +205,7 @@ All items must be of the type:
 
 
 `refnamed`
+
 * is optional
 * type: Simple
 * defined in this schema
@@ -213,6 +224,7 @@ All items must be of the type:
 Exclusive choice.
 
 `xor`
+
 * is optional
 * type: complex
 * defined in this schema
@@ -227,6 +239,7 @@ Exclusive choice.
 
 
 `number`
+
 * maximum value: `0`
 
 
@@ -234,6 +247,7 @@ Exclusive choice.
 
 
 `number`
+
 * minimum value: `10`
 
 
@@ -247,6 +261,7 @@ Applies to all properties that match the regular expression `int.*`
 
 
 `int.*`
+
 * is a property pattern
 * type: `integer`
 * defined in this schema
@@ -261,11 +276,13 @@ Applies to all properties that match the regular expression `int.*`
 
 
 
+
 ## Pattern: `str.*`
 Applies to all properties that match the regular expression `str.*`
 
 
 `str.*`
+
 * is a property pattern
 * type: `string`
 * defined in this schema
@@ -274,6 +291,7 @@ Applies to all properties that match the regular expression `str.*`
 
 
 `string`
+
 
 
 

--- a/spec/examples/constants.schema.md
+++ b/spec/examples/constants.schema.md
@@ -27,6 +27,7 @@ This is an example schema with examples for properties with constant values
 A simple string, without strong constraints.
 
 `hello`
+
 * is **required**
 * type: `const`
 * defined in this schema

--- a/spec/examples/custom.schema.md
+++ b/spec/examples/custom.schema.md
@@ -28,6 +28,7 @@ This is an extensible schema. It has `definitions`, that can be used in other sc
 A unique identifier given to every addressable thing.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -42,11 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## foo
 
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -55,6 +58,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 
 
 

--- a/spec/examples/deepextending.schema.md
+++ b/spec/examples/deepextending.schema.md
@@ -39,6 +39,7 @@ This is an extending schema. It is extending another extending schema. It pulls 
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id)
@@ -47,6 +48,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -59,6 +61,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in [Extensible](extensible.schema.md#bar)
@@ -67,6 +70,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -90,6 +94,7 @@ A horse walks into it.
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
+
 * is optional
 * type: `string`
 * defined in [Extending](extending.schema.md#baz)
@@ -98,6 +103,7 @@ This property has a unique name to demonstrate it's uniqueness.
 
 
 `string`
+
 
 
 
@@ -115,6 +121,7 @@ This property has a unique name to demonstrate it's uniqueness.
 A unique identifier given to every addressable thing.
 
 `hey`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -129,11 +136,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
 ## id
 
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id-1)
@@ -142,6 +151,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -154,6 +164,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#metaid)
@@ -162,6 +173,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/spec/examples/definitions.schema.md
+++ b/spec/examples/definitions.schema.md
@@ -46,6 +46,7 @@ aks.
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -54,6 +55,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -66,6 +68,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is **required**
 * type: `string`
 * defined in this schema
@@ -74,6 +77,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -86,6 +90,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -94,6 +99,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/spec/examples/enums.schema.md
+++ b/spec/examples/enums.schema.md
@@ -28,6 +28,7 @@ This is an example schema with examples for properties with enum values
 A simple string. Pick a value.
 
 `hello`
+
 * is **required**
 * type: `enum`
 * defined in this schema
@@ -49,6 +50,7 @@ The value of this property **must** be equal to one of the [known values below](
 This is an example schema with examples for properties of nested objects with enum values
 
 `nested`
+
 * is optional
 * type: `object`
 * defined in this schema
@@ -70,6 +72,7 @@ This is an example schema with examples for properties of nested objects with en
 A simple string. Pick a value.
 
 `test`
+
 * is optional
 * type: `enum`
 

--- a/spec/examples/example.schema.md
+++ b/spec/examples/example.schema.md
@@ -36,6 +36,7 @@ This is an example schema with examples. Too many examples? There can never be t
 A simple string.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -44,6 +45,7 @@ A simple string.
 
 
 `string`
+
 
 
 
@@ -66,6 +68,7 @@ A simple string.
 A simple string.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -74,6 +77,7 @@ A simple string.
 
 
 `string`
+
 
 
 

--- a/spec/examples/examples.schema.md
+++ b/spec/examples/examples.schema.md
@@ -45,6 +45,7 @@ This is an example schema with *multiple* examples. Too many examples? There can
 A simple string.
 
 `bar`
+
 * is **required**
 * type: `string`
 * defined in this schema
@@ -53,6 +54,7 @@ A simple string.
 
 
 `string`
+
 
 
 
@@ -75,6 +77,7 @@ A simple string.
 A simple string.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -83,6 +86,7 @@ A simple string.
 
 
 `string`
+
 
 
 

--- a/spec/examples/extending.schema.md
+++ b/spec/examples/extending.schema.md
@@ -37,6 +37,7 @@ This is an extending schema. It pulls `definitions` from other schemas.
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id)
@@ -45,6 +46,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -57,6 +59,7 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in [Extensible](extensible.schema.md#bar)
@@ -65,6 +68,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -88,6 +92,7 @@ A horse walks into it.
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -96,6 +101,7 @@ This property has a unique name to demonstrate it's uniqueness.
 
 
 `string`
+
 
 
 
@@ -113,6 +119,7 @@ This property has a unique name to demonstrate it's uniqueness.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#id-1)
@@ -121,6 +128,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 
@@ -133,6 +141,7 @@ A unique identifier given to every addressable thing.
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
+
 * is optional
 * type: `string`
 * defined in [Definitions](definitions.schema.md#metaid)
@@ -141,6 +150,7 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 

--- a/spec/examples/extensible.schema.md
+++ b/spec/examples/extensible.schema.md
@@ -27,6 +27,7 @@ This is an extensible schema. It has `definitions`, that can be used in other sc
 A horse walks into it.
 
 `bar`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A horse walks into it.
 
 
 `string`
+
 
 
 
@@ -57,6 +59,7 @@ A horse walks into it.
 A unique identifier given to every addressable thing.
 
 `foo`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -65,6 +68,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 
 
 

--- a/spec/examples/identifiable.schema.md
+++ b/spec/examples/identifiable.schema.md
@@ -27,6 +27,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 A unique identifier given to every addressable thing.
 
 `@id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/spec/examples/simple.schema.md
+++ b/spec/examples/simple.schema.md
@@ -27,6 +27,7 @@ This is a *very* simple example of a JSON schema. There is only one property.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/spec/examples/simpletypes.schema.md
+++ b/spec/examples/simpletypes.schema.md
@@ -43,6 +43,7 @@ This is an example schema with examples for multiple types and their constraints
 Guess what number is valid
 
 `integer_threes`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -51,6 +52,7 @@ Guess what number is valid
 
 
 `integer`
+
 * minimum value: `2`
 * maximum value: `4`
 * must be a multiple of `3`
@@ -64,6 +66,7 @@ Guess what number is valid
 Just a whole number. I don't like fractions. Don't get too small
 
 `interger_constrained`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -72,6 +75,7 @@ Just a whole number. I don't like fractions. Don't get too small
 
 
 `integer`
+
 * minimum value: `10`
 
 
@@ -84,6 +88,7 @@ Just a whole number. I don't like fractions. Don't get too small
 Just a whole number. I don't like fractions.
 
 `interger_unconstrained`
+
 * is optional
 * type: `integer`
 * defined in this schema
@@ -98,11 +103,13 @@ Just a whole number. I don't like fractions.
 
 
 
+
 ## number_constrained
 
 Just a number. Don't get too big.
 
 `number_constrained`
+
 * is optional
 * type: `number`
 * defined in this schema
@@ -111,6 +118,7 @@ Just a number. Don't get too big.
 
 
 `number`
+
 * value must not be greater or equal than: `10`
 
 
@@ -122,6 +130,7 @@ Just a number. Don't get too big.
 Just a number
 
 `number_unconstrained`
+
 * is optional
 * type: `number`
 * defined in this schema
@@ -136,11 +145,13 @@ Just a number
 
 
 
+
 ## string_date
 
 A date-like string.
 
 `string_date`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -149,6 +160,7 @@ A date-like string.
 
 
 `string`
+
 * format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 
@@ -161,6 +173,7 @@ A date-like string.
 An email-like string.
 
 `string_email`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -169,6 +182,7 @@ An email-like string.
 
 
 `string`
+
 * format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 
@@ -181,6 +195,7 @@ An email-like string.
 A hostname-like string.
 
 `string_hostname`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -189,6 +204,7 @@ A hostname-like string.
 
 
 `string`
+
 * format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
 
 
@@ -201,6 +217,7 @@ A hostname-like string.
 An IPv4-like string.
 
 `string_ipv4`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -209,6 +226,7 @@ An IPv4-like string.
 
 
 `string`
+
 * format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
 
 
@@ -221,6 +239,7 @@ An IPv4-like string.
 An IPv6-like string.
 
 `string_ipv6`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -229,6 +248,7 @@ An IPv6-like string.
 
 
 `string`
+
 * format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
 
 
@@ -241,6 +261,7 @@ An IPv6-like string.
 A string with minumum and maximum length
 
 `string_length`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -249,6 +270,7 @@ A string with minumum and maximum length
 
 
 `string`
+
 * minimum length: 3 characters
 * maximum length: 3 characters
 
@@ -271,6 +293,7 @@ A string with minumum and maximum length
 A string following a regular expression
 
 `string_pattern`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -279,6 +302,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -328,6 +352,7 @@ All instances must conform to this regular expression
 A string following a regular expression
 
 `string_pattern_noexample`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -336,6 +361,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -354,6 +380,7 @@ All instances must conform to this regular expression
 A string following a regular expression
 
 `string_pattern_singleexample`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -362,6 +389,7 @@ A string following a regular expression
 
 
 `string`
+
 
 
 All instances must conform to this regular expression 
@@ -386,6 +414,7 @@ All instances must conform to this regular expression
 A simple string, without any constraints.
 
 `string_unconstrained`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -394,6 +423,7 @@ A simple string, without any constraints.
 
 
 `string`
+
 
 
 
@@ -411,6 +441,7 @@ A simple string, without any constraints.
 A URI.
 
 `string_uri`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -419,6 +450,7 @@ A URI.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 
@@ -430,6 +462,7 @@ A URI.
 
 
 `yesno`
+
 * is **required**
 * type: `boolean`
 * defined in this schema

--- a/spec/examples/stabilizing.schema.md
+++ b/spec/examples/stabilizing.schema.md
@@ -27,6 +27,7 @@ This is a schema which is currently in the `stabilizing` status.
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -35,6 +36,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/templates/md/nested-property.ejs
+++ b/templates/md/nested-property.ejs
@@ -13,6 +13,8 @@
 
 
 `<%=name %>`
+
+
 * is <% if (required) { %>**required**<% } else { %>optional<% } %>
 * type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
 <%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 

--- a/templates/md/nested-property.ejs
+++ b/templates/md/nested-property.ejs
@@ -16,8 +16,8 @@
 
 
 * is <% if (required) { %>**required**<% } else { %>optional<% } %>
-* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
-<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 
+* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { -%>
+<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% }
 else if (schema.maxItems!==undefined                             ) { %>* no more than `<%=schema.maxItems %>` items in the array<% }
 else if (schema.minItems!==undefined                             ) { %>* at least `<%=schema.minItems %>` items in the array<% } %>
 <% } %><% if (schema.default!==undefined) { %>

--- a/templates/md/number-type.ejs
+++ b/templates/md/number-type.ejs
@@ -6,13 +6,15 @@
  */ %>
 
 `<%=schema.type %>`
-<% if(schema.exclusiveMinumum!==undefined) { 
-  %>* value must not be smaller or equal than: `<%=schema.exclusiveMinumum %>`<% 
-  } else if(schema.minimum!==undefined) { 
+
+
+<% if(schema.exclusiveMinumum!==undefined) {
+  %>* value must not be smaller or equal than: `<%=schema.exclusiveMinumum %>`<%
+  } else if(schema.minimum!==undefined) {
   %>* minimum value: `<%=schema.minimum %>`<% } %>
-<% if(schema.exclusiveMaximum!==undefined) { 
-  %>* value must not be greater or equal than: `<%=schema.exclusiveMaximum %>`<% 
-  }  if(schema.maximum!==undefined) { 
+<% if(schema.exclusiveMaximum!==undefined) {
+  %>* value must not be greater or equal than: `<%=schema.exclusiveMaximum %>`<%
+  }  if(schema.maximum!==undefined) {
   %>* maximum value: `<%=schema.maximum %>`<% } %>
-<% if(schema.multipleOf!==undefined) { 
+<% if(schema.multipleOf!==undefined) {
   %>* must be a multiple of `<%=schema.multipleOf %>`<% } %>

--- a/templates/md/pattern-property.ejs
+++ b/templates/md/pattern-property.ejs
@@ -19,8 +19,8 @@ Applies to all properties that match the regular expression `<%=name %>`
 
 
 * is a property pattern
-* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
-<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 
+* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { -%>
+<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% }
 else if (schema.maxItems!==undefined                             ) { %>* no more than `<%=schema.maxItems %>` items in the array<% }
 else if (schema.minItems!==undefined                             ) { %>* at least `<%=schema.minItems %>` items in the array<% } %>
 <% } %><% if (schema.default!==undefined) { %>

--- a/templates/md/pattern-property.ejs
+++ b/templates/md/pattern-property.ejs
@@ -16,6 +16,8 @@ Applies to all properties that match the regular expression `<%=name %>`
 <% } %>
 
 `<%=name %>`
+
+
 * is a property pattern
 * type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
 <%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 

--- a/templates/md/property.ejs
+++ b/templates/md/property.ejs
@@ -16,13 +16,17 @@
 
 
 * is <% if (required) { %>**required**<% } else { %>optional<% } %>
-* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { -%>
-<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% }
-else if (schema.maxItems!==undefined                             ) { %>* no more than `<%=schema.maxItems %>` items in the array<% }
-else if (schema.minItems!==undefined                             ) { %>* at least `<%=schema.minItems %>` items in the array<% } %>
-<% } %><% if (schema.default!==undefined) { %>
+* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %>
+<% if (schema.type==='array') { %><% if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>
+* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array
+<% } else if (schema.maxItems!==undefined) { %>
+* no more than `<%=schema.maxItems %>` items in the array
+<% } else if (schema.minItems!==undefined) { %>
+* at least `<%=schema.minItems %>` items in the array<% } %>
+<% } -%>
+<% if (schema.default!==undefined) { %>
 * default: `<%- JSON.stringify(schema.default) %>`
-<% } %>
+<% } -%>
 * defined in <% if (schema.$oSchema) { %>[<%= schema.$oSchema.$linkVal %>](<%= schema.$oSchema.$linkPath %>#<%= nameSlug %>)<% } else { %>this schema<% } %>
 
 <% if (schema.const!==undefined) { %>

--- a/templates/md/property.ejs
+++ b/templates/md/property.ejs
@@ -13,6 +13,8 @@
 <% } %>
 
 `<%=name %>`
+
+
 * is <% if (required) { %>**required**<% } else { %>optional<% } %>
 * type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
 <%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 

--- a/templates/md/property.ejs
+++ b/templates/md/property.ejs
@@ -16,8 +16,8 @@
 
 
 * is <% if (required) { %>**required**<% } else { %>optional<% } %>
-* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { %>
-<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% } 
+* type: <%=schema.simpletype %><% if (schema.simpletype.match(/\[\]\[\]/)||schema.simpletype==="`array[]`") { %> (nested array)<% } %><% if (schema.type==='array') { -%>
+<%   if (schema.maxItems!==undefined&&schema.minItems!==undefined) { %>* between `<%=schema.minItems %>` and `<%=schema.maxItems %>` items in the array<% }
 else if (schema.maxItems!==undefined                             ) { %>* no more than `<%=schema.maxItems %>` items in the array<% }
 else if (schema.minItems!==undefined                             ) { %>* at least `<%=schema.minItems %>` items in the array<% } %>
 <% } %><% if (schema.default!==undefined) { %>

--- a/templates/md/string-type.ejs
+++ b/templates/md/string-type.ejs
@@ -6,6 +6,8 @@
  */ %>
 
 `string`
+
+
 <% 
      if (schema.format==="uri") {                   %>* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))<% } 
 else if (schema.format==="date-time") {             %>* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))<% } 


### PR DESCRIPTION
Fixes #86 

There are a few unintended extra newlines scattered about that do not affect the rendered markdown.