### PR TITLE
Handles array with join-type, schemas with only join-types and schemas with only pattern properties

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -19,6 +19,7 @@
 * [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
 * [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
 * [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+* [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
 * [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
 * [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
 * [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -19,6 +19,7 @@
 * [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
 * [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
 * [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+* [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
 * [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
 * [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
 * [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)

--- a/examples/docs/arrays.schema.md
+++ b/examples/docs/arrays.schema.md
@@ -19,6 +19,7 @@ This is an example schema with examples for multiple array types and their const
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
+| [JoinTypelist](#jointypelist) | `array` | Optional | Arrays (this schema) |
 | [boollist](#boollist) | `boolean[]` | Optional | Arrays (this schema) |
 | [coordinatelist](#coordinatelist) | `number[][]` | Optional | Arrays (this schema) |
 | [intlist](#intlist) | `integer[]` | Optional | Arrays (this schema) |
@@ -28,6 +29,114 @@ This is an example schema with examples for multiple array types and their const
 | [objectlist](#objectlist) | `object[]` | Optional | Arrays (this schema) |
 | [stringlistlist](#stringlistlist) | `string[][]` | Optional | Arrays (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
+
+## JoinTypelist
+
+An array of simple objects
+
+`JoinTypelist`
+
+* is optional
+* type: `array`
+* defined in this schema
+
+### JoinTypelist Type
+
+
+Array type: `array`
+
+All items must be of the type:
+
+**One** of the following *conditions* need to be fulfilled.
+
+
+#### Condition 1
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `foo`| string | Optional |
+
+
+
+#### foo
+
+A simple string.
+
+`foo`
+
+* is optional
+* type: `string`
+
+##### foo Type
+
+
+`string`
+
+
+
+
+
+
+##### foo Example
+
+```json
+hello
+```
+
+
+
+
+#### Condition 2
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `bar`| string | Optional |
+
+
+
+#### bar
+
+A simple string.
+
+`bar`
+
+* is optional
+* type: `string`
+
+##### bar Type
+
+
+`string`
+
+
+
+
+
+
+##### bar Example
+
+```json
+world
+```
+
+
+
+
+  
+
+
+
+
+
+
 
 ## boollist
 

--- a/examples/docs/custom.schema.md
+++ b/examples/docs/custom.schema.md
@@ -64,3 +64,25 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
+
+
+#### Requirement 2
+
+
+* []() – `#/definitions/first`
+
+
+#### Requirement 3
+
+
+* []() – `#/definitions/second`
+

--- a/examples/docs/deepextending.schema.md
+++ b/examples/docs/deepextending.schema.md
@@ -180,3 +180,31 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://example.com/schemas/extensible#/definitions/second`
+
+
+#### Requirement 2
+
+
+* []() – `https://example.com/schemas/definitions#/definitions/myid`
+
+
+#### Requirement 3
+
+
+* []() – `https://example.com/schemas/extending#/definitions/third`
+
+
+#### Requirement 4
+
+
+* []() – `#/definitions/fourth`
+

--- a/examples/docs/definitions.schema.md
+++ b/examples/docs/definitions.schema.md
@@ -106,3 +106,13 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/myid`
+

--- a/examples/docs/extending.schema.md
+++ b/examples/docs/extending.schema.md
@@ -157,3 +157,25 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://example.com/schemas/extensible#/definitions/second`
+
+
+#### Requirement 2
+
+
+* []() – `https://example.com/schemas/definitions#/definitions/myid`
+
+
+#### Requirement 3
+
+
+* []() – `#/definitions/third`
+

--- a/examples/docs/identifiable.schema.md
+++ b/examples/docs/identifiable.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/examples/docs/join.schema.md
+++ b/examples/docs/join.schema.md
@@ -1,0 +1,100 @@
+---
+template: reference
+foo: bar
+---
+
+# Join Types Schema
+
+```
+https://example.com/schemas/join
+```
+
+This is an example of a JSON schema with only a join type key. Here a 'oneOf'.
+
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [join.schema.json](join.schema.json) |
+
+
+**One** of the following *conditions* need to be fulfilled.
+
+
+#### Condition 1
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `foo`| string | Optional |
+
+
+
+#### foo
+
+A simple string.
+
+`foo`
+
+* is optional
+* type: `string`
+
+##### foo Type
+
+
+`string`
+
+
+
+
+
+
+##### foo Example
+
+```json
+hello
+```
+
+
+
+
+#### Condition 2
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `bar`| string | Optional |
+
+
+
+#### bar
+
+A simple string.
+
+`bar`
+
+* is optional
+* type: `string`
+
+##### bar Type
+
+
+`string`
+
+
+
+
+
+
+##### bar Example
+
+```json
+world
+```
+
+
+

--- a/examples/docs/pattern.schema.md
+++ b/examples/docs/pattern.schema.md
@@ -1,0 +1,45 @@
+---
+template: reference
+foo: bar
+---
+
+# Pattern Properties Schema
+
+```
+https://example.com/schemas/pattern
+```
+
+This is an example of a JSON schema with only a `patternProperties` key.
+
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [pattern.schema.json](pattern.schema.json) |
+
+## Pattern: `[0-9]`
+Applies to all properties that match the regular expression `[0-9]`
+
+
+A simple string.
+
+`[0-9]`
+
+* is a property pattern
+* type: `string`
+* defined in this schema
+
+### Pattern [0-9] Type
+
+
+`string`
+
+
+
+
+
+
+### [0-9] Example
+
+```json
+"bar"
+```
+

--- a/examples/docs/simple.schema.md
+++ b/examples/docs/simple.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/examples/docs/stabilizing.schema.md
+++ b/examples/docs/stabilizing.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/examples/docs/subdir/subdir.schema.md
+++ b/examples/docs/subdir/subdir.schema.md
@@ -15,6 +15,16 @@ A schema in a sub directory
 |-------------------------------|------------|---------------------------|--------------|-------------------|-----------------------|------------|
 | Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir/subdir.schema.json) |
 
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+
+
 # Subdir Definitions
 
 | Property | Type | Group |

--- a/examples/generated-schemas/arrays.schema.json
+++ b/examples/generated-schemas/arrays.schema.json
@@ -96,6 +96,40 @@
                     }
                 }
             }
+        },
+        "JoinTypelist": {
+            "type": "array",
+            "description": "An array of simple objects",
+            "items": {
+                "oneOf": [
+                    {
+                        "type": "object",
+                        "description": "A simple string.",
+                        "properties": {
+                            "foo": {
+                                "type": "string",
+                                "description": "A simple string.",
+                                "examples": [
+                                    "hello"
+                                ]
+                            }
+                        }
+                    },
+                    {
+                        "type": "object",
+                        "description": "Another simple string.",
+                        "properties": {
+                            "bar": {
+                                "type": "string",
+                                "description": "A simple string.",
+                                "examples": [
+                                    "world"
+                                ]
+                            }
+                        }
+                    }
+                ]
+            }
         }
     }
 }

--- a/examples/generated-schemas/join.schema.json
+++ b/examples/generated-schemas/join.schema.json
@@ -1,0 +1,40 @@
+{
+    "meta:license": [
+        "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the 'License');",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0"
+    ],
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/schemas/join",
+    "title": "Join Types",
+    "description": "This is an example of a JSON schema with only a join type key. Here a 'oneOf'.",
+    "oneOf": [
+        {
+            "type": "object",
+            "description": "A simple string.",
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "description": "A simple string.",
+                    "examples": [
+                        "hello"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "object",
+            "description": "Another simple string.",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "description": "A simple string.",
+                    "examples": [
+                        "world"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/examples/generated-schemas/pattern.schema.json
+++ b/examples/generated-schemas/pattern.schema.json
@@ -1,0 +1,21 @@
+{
+    "meta:license": [
+        "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the 'License');",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0"
+    ],
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/schemas/pattern",
+    "title": "Pattern Properties",
+    "description": "This is an example of a JSON schema with only a `patternProperties` key.",
+    "patternProperties": {
+        "[0-9]": {
+            "type": "string",
+            "description": "A simple string.",
+            "examples": [
+                "bar"
+            ]
+        }
+    }
+}

--- a/examples/schemas/arrays.schema.json
+++ b/examples/schemas/arrays.schema.json
@@ -12,31 +12,31 @@
   "description": "This is an example schema with examples for multiple array types and their constraints.",
   "properties": {
     "list": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array",
       "items": {
         "type": "string"
       }
     },
     "listlist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array of arrays",
       "items": {
         "type": "array"
       }
     },
     "stringlistlist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array of arrays of strings",
       "items": {
         "type": "array",
         "items": {
-          "type":"string"
+          "type": "string"
         }
       }
     },
     "intlist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array",
       "items": {
         "type": "integer"
@@ -45,7 +45,7 @@
       "minItems": 1
     },
     "boollist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array",
       "items": {
         "type": "boolean"
@@ -53,7 +53,7 @@
       "minItems": 1
     },
     "numlist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array",
       "items": {
         "type": "number",
@@ -62,7 +62,7 @@
       "maxItems": 10
     },
     "coordinatelist": {
-      "type":"array",
+      "type": "array",
       "description": "This is an array of coordinates in three-dimensional space.",
       "items": {
         "type": "array",
@@ -70,7 +70,7 @@
         "maxItems": 3,
         "description": "A coordinate, specified by `x`, `y`, and `z` values",
         "items": {
-          "type":"number",
+          "type": "number",
           "minimum": 0,
           "maximum": 10
         }
@@ -91,10 +91,44 @@
             "description": "The a property"
           },
           "b": {
-            "type":"integer",
+            "type": "integer",
             "description": "The b property"
           }
         }
+      }
+    },
+    "JoinTypelist": {
+      "type": "array",
+      "description": "An array of simple objects",
+      "items": {
+        "oneOf": [
+          {
+            "type": "object",
+            "description": "A simple string.",
+            "properties": {
+              "foo": {
+                "type": "string",
+                "description": "A simple string.",
+                "examples": [
+                  "hello"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
+            "description": "Another simple string.",
+            "properties": {
+              "bar": {
+                "type": "string",
+                "description": "A simple string.",
+                "examples": [
+                  "world"
+                ]
+              }
+            }
+          }
+        ]
       }
     }
   }

--- a/examples/schemas/join.schema.json
+++ b/examples/schemas/join.schema.json
@@ -1,0 +1,40 @@
+{
+    "meta:license": [
+        "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the 'License');",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0"
+    ],
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/schemas/join",
+    "title": "Join Types",
+    "description": "This is an example of a JSON schema with only a join type key. Here a 'oneOf'.",
+    "oneOf": [
+        {
+            "type": "object",
+            "description": "A simple string.",
+            "properties": {
+                "foo": {
+                    "type": "string",
+                    "description": "A simple string.",
+                    "examples": [
+                        "hello"
+                    ]
+                }
+            }
+        },
+        {
+            "type": "object",
+            "description": "Another simple string.",
+            "properties": {
+                "bar": {
+                    "type": "string",
+                    "description": "A simple string.",
+                    "examples": [
+                        "world"
+                    ]
+                }
+            }
+        }
+    ]
+}

--- a/examples/schemas/pattern.schema.json
+++ b/examples/schemas/pattern.schema.json
@@ -1,0 +1,19 @@
+{
+    "meta:license": [
+        "Copyright 2017 Adobe Systems Incorporated. All rights reserved.",
+        "This file is licensed to you under the Apache License, Version 2.0 (the 'License');",
+        "you may not use this file except in compliance with the License. You may obtain a copy",
+        "of the License at http://www.apache.org/licenses/LICENSE-2.0"
+    ],
+    "$schema": "http://json-schema.org/draft-06/schema#",
+    "$id": "https://example.com/schemas/pattern",
+    "title": "Pattern Properties",
+    "description": "This is an example of a JSON schema with only a `patternProperties` key.",
+    "patternProperties": {
+        "[0-9]": {
+            "type": "string",
+            "description": "A simple string.",
+            "examples": ["bar"]
+        }
+    }
+}

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -170,7 +170,6 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
     //[ 'topSchema.ejs', ctx ],
     [ 'examples.ejs', { examples: stringifyExamples(schema.examples), title: schema.title } ]
   ];
-
   if (_.keys(schema.properties).length > 0) {
     //table of contents
     multi.push([ 'properties.ejs', {
@@ -192,6 +191,9 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
         nameSlug: propertiesSlugs[name]
       } ]);
     }
+  }
+
+  if (_.keys(schema.patternProperties).length > 0) {
     //patterns properties
     for (let i=0; i<_.keys(schema.patternProperties).length;i++) {
       const name = _.keys(schema.patternProperties)[i];

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -204,6 +204,20 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
         schema: simpletype(schema.patternProperties[name]) } ]);
     }
   }
+
+  // Handles join-type properties
+  // If the schema contains a 'oneOf', 'allOf' or 'anyOf'.
+  const joinTypeKey = Object.keys(schema).find(key => [ 'oneOf', 'allOf', 'anyOf' ].indexOf(key) > -1);
+  if (!_.isUndefined(joinTypeKey)) {
+    const joinType = schema[joinTypeKey];
+    if (joinType.length > 0) {
+      multi.push( [ 'join-type.ejs', {
+        ejs: ejsRender,
+        schemas: simpletype(joinType),
+        schema: simpletype(schema) } ]);
+    }
+  }
+
   //find definitions that contain properties that are not part of the main schema
   if (_.keys(schema.definitions).length > 0) {
     const abstract = {};

--- a/lib/schema.js
+++ b/lib/schema.js
@@ -353,9 +353,18 @@ Schema.getExamples = function(filePath, schema){
         return fs.readFileAsync(entry).then(example => {
           var data = JSON.parse(example.toString());
           var valid = validate(data);
-          if (valid) {examples.push(data);} else {logger.error(entry+' is an invalid Example');}
+          if (valid) {examples.push({ filename: entry, data: data });} else {logger.error(entry+' is an invalid Example');}
         });
-      }).then(() => {schema.examples=examples; return schema; } );
+      }).then(() => {
+        // Sort according to filenames in order not to have random prints
+        examples.sort(function(a, b) {
+          return a.filename > b.filename ? 1 : -1;
+        });
+        logger.error(examples);
+        examples = examples.map(function(element) {return element.data; });
+        schema.examples=examples;
+        return schema;
+      });
     } else {return schema;}
   });
 };

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -19,6 +19,7 @@
 * [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
 * [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
 * [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+* [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
 * [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
 * [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
 * [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -19,6 +19,7 @@
 * [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
 * [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
 * [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+* [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
 * [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
 * [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
 * [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)

--- a/spec/examples/arrays.schema.md
+++ b/spec/examples/arrays.schema.md
@@ -19,6 +19,7 @@ This is an example schema with examples for multiple array types and their const
 
 | Property | Type | Required | Defined by |
 |----------|------|----------|------------|
+| [JoinTypelist](#jointypelist) | `array` | Optional | Arrays (this schema) |
 | [boollist](#boollist) | `boolean[]` | Optional | Arrays (this schema) |
 | [coordinatelist](#coordinatelist) | `number[][]` | Optional | Arrays (this schema) |
 | [intlist](#intlist) | `integer[]` | Optional | Arrays (this schema) |
@@ -28,6 +29,114 @@ This is an example schema with examples for multiple array types and their const
 | [objectlist](#objectlist) | `object[]` | Optional | Arrays (this schema) |
 | [stringlistlist](#stringlistlist) | `string[][]` | Optional | Arrays (this schema) |
 | `*` | any | Additional | this schema *allows* additional properties |
+
+## JoinTypelist
+
+An array of simple objects
+
+`JoinTypelist`
+
+* is optional
+* type: `array`
+* defined in this schema
+
+### JoinTypelist Type
+
+
+Array type: `array`
+
+All items must be of the type:
+
+**One** of the following *conditions* need to be fulfilled.
+
+
+#### Condition 1
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `foo`| string | Optional |
+
+
+
+#### foo
+
+A simple string.
+
+`foo`
+
+* is optional
+* type: `string`
+
+##### foo Type
+
+
+`string`
+
+
+
+
+
+
+##### foo Example
+
+```json
+hello
+```
+
+
+
+
+#### Condition 2
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `bar`| string | Optional |
+
+
+
+#### bar
+
+A simple string.
+
+`bar`
+
+* is optional
+* type: `string`
+
+##### bar Type
+
+
+`string`
+
+
+
+
+
+
+##### bar Example
+
+```json
+world
+```
+
+
+
+
+  
+
+
+
+
+
+
 
 ## boollist
 

--- a/spec/examples/custom.schema.md
+++ b/spec/examples/custom.schema.md
@@ -64,3 +64,25 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
+
+
+#### Requirement 2
+
+
+* []() – `#/definitions/first`
+
+
+#### Requirement 3
+
+
+* []() – `#/definitions/second`
+

--- a/spec/examples/deepextending.schema.md
+++ b/spec/examples/deepextending.schema.md
@@ -180,3 +180,31 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://example.com/schemas/extensible#/definitions/second`
+
+
+#### Requirement 2
+
+
+* []() – `https://example.com/schemas/definitions#/definitions/myid`
+
+
+#### Requirement 3
+
+
+* []() – `https://example.com/schemas/extending#/definitions/third`
+
+
+#### Requirement 4
+
+
+* []() – `#/definitions/fourth`
+

--- a/spec/examples/definitions.schema.md
+++ b/spec/examples/definitions.schema.md
@@ -106,3 +106,13 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/myid`
+

--- a/spec/examples/extending.schema.md
+++ b/spec/examples/extending.schema.md
@@ -157,3 +157,25 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `https://example.com/schemas/extensible#/definitions/second`
+
+
+#### Requirement 2
+
+
+* []() – `https://example.com/schemas/definitions#/definitions/myid`
+
+
+#### Requirement 3
+
+
+* []() – `#/definitions/third`
+

--- a/spec/examples/identifiable.schema.md
+++ b/spec/examples/identifiable.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/spec/examples/join.schema.md
+++ b/spec/examples/join.schema.md
@@ -1,0 +1,100 @@
+---
+template: reference
+foo: bar
+---
+
+# Join Types Schema
+
+```
+https://example.com/schemas/join
+```
+
+This is an example of a JSON schema with only a join type key. Here a 'oneOf'.
+
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [join.schema.json](join.schema.json) |
+
+
+**One** of the following *conditions* need to be fulfilled.
+
+
+#### Condition 1
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `foo`| string | Optional |
+
+
+
+#### foo
+
+A simple string.
+
+`foo`
+
+* is optional
+* type: `string`
+
+##### foo Type
+
+
+`string`
+
+
+
+
+
+
+##### foo Example
+
+```json
+hello
+```
+
+
+
+
+#### Condition 2
+
+
+`object` with following properties:
+
+
+| Property | Type | Required |
+|----------|------|----------|
+| `bar`| string | Optional |
+
+
+
+#### bar
+
+A simple string.
+
+`bar`
+
+* is optional
+* type: `string`
+
+##### bar Type
+
+
+`string`
+
+
+
+
+
+
+##### bar Example
+
+```json
+world
+```
+
+
+

--- a/spec/examples/pattern.schema.md
+++ b/spec/examples/pattern.schema.md
@@ -1,0 +1,45 @@
+---
+template: reference
+foo: bar
+---
+
+# Pattern Properties Schema
+
+```
+https://example.com/schemas/pattern
+```
+
+This is an example of a JSON schema with only a `patternProperties` key.
+
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [pattern.schema.json](pattern.schema.json) |
+
+## Pattern: `[0-9]`
+Applies to all properties that match the regular expression `[0-9]`
+
+
+A simple string.
+
+`[0-9]`
+
+* is a property pattern
+* type: `string`
+* defined in this schema
+
+### Pattern [0-9] Type
+
+
+`string`
+
+
+
+
+
+
+### [0-9] Example
+
+```json
+"bar"
+```
+

--- a/spec/examples/simple.schema.md
+++ b/spec/examples/simple.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/spec/examples/stabilizing.schema.md
+++ b/spec/examples/stabilizing.schema.md
@@ -43,3 +43,13 @@ A unique identifier given to every addressable thing.
 
 
 
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+

--- a/spec/examples/subdir/subdir.schema.md
+++ b/spec/examples/subdir/subdir.schema.md
@@ -11,9 +11,19 @@ https://example.com/schemas/subdir/subdir
 
 A schema in a sub directory
 
-| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Custom Properties | Additional Properties | Defined In |
-|-------------------------------|------------|---------------------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | Forbidden | Permitted | [subdir/subdir.schema.json](subdir/subdir.schema.json) |
+| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
+|-------------------------------|------------|---------------------------|--------------|-------------------|-----------------------|------------|
+| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir/subdir.schema.json) |
+
+
+**All** of the following *requirements* need to be fulfilled.
+
+
+#### Requirement 1
+
+
+* []() – `#/definitions/id`
+
 
 # Subdir Definitions
 
@@ -26,6 +36,7 @@ A schema in a sub directory
 A unique identifier given to every addressable thing.
 
 `id`
+
 * is optional
 * type: `string`
 * defined in this schema
@@ -34,6 +45,7 @@ A unique identifier given to every addressable thing.
 
 
 `string`
+
 * format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 

--- a/spec/lib/integrationTest.spec.js
+++ b/spec/lib/integrationTest.spec.js
@@ -54,7 +54,7 @@ describe('Compare results', () => {
     ls.on('close', code => {
       expect(code).toEqual(0);
       const files = readdirSync('./spec/examples').filter(item => !(/(^|\/)\.[^\/\.]/g).test(item));
-      expect(files.length).toEqual(18);
+      expect(files.length).toEqual(19);
       done();
     });
   });

--- a/spec/lib/integrationTest.spec.js
+++ b/spec/lib/integrationTest.spec.js
@@ -54,7 +54,7 @@ describe('Compare results', () => {
     ls.on('close', code => {
       expect(code).toEqual(0);
       const files = readdirSync('./spec/examples').filter(item => !(/(^|\/)\.[^\/\.]/g).test(item));
-      expect(files.length).toEqual(19);
+      expect(files.length).toEqual(20);
       done();
     });
   });

--- a/templates/md/array-type.ejs
+++ b/templates/md/array-type.ejs
@@ -22,6 +22,8 @@ if (schema.items.type==="string") {
   %><%- include("object-type",{schema:schema.items,_:_}) 
   %><% } else if (schema.items.type==="array") { 
   %><%- include("array-type",{schema:schema.items,_:_, nested:true}) 
+  %><% } else if (schema.items.anyOf!==undefined || schema.items.allOf!==undefined || schema.items.oneOf!==undefined) {
+  %><%- include("join-type",{schema:schema.items,_:_,schemas:schema.items.anyOf || schema.items.allOf || schema.items.oneOf, ejs:ejs}) %>
   %><% } else if (schema.items.$ref!==undefined) { 
   %><%- include("referenced-type",{schema:schema.items,_:_}) %>
 <% } else { %>

--- a/templates/md/join-type.ejs
+++ b/templates/md/join-type.ejs
@@ -31,6 +31,8 @@
 <%- include("boolean-type",{schema:schemas[i],_:_}) %>
 <% } else if (schemas[i].type==="array") { %>
 <%- include("array-type",{schema:schemas[i],_:_,nested:false,ejs:ejs}) %>
+<% } else if (schemas[i].type==="object") { %>
+<%- include("object-type",{schema:schemas[i],_:_, nameSlug:_}) %>
 <% } else if (schemas[i].$ref!==undefined) { %>
 <%- include("referenced-type",{schema:schemas[i],_:_}) %>
 <% } else if (schemas[i].anyOf!==undefined||schemas[i].allOf!==undefined) { %>


### PR DESCRIPTION
I'm currently building a schema validator and wanted to use jsonschema2md in order to generated its documentation.

1 - Some of my schemas are just defined by join type properties as follow:

```json

{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "...",
    "title": "...",
    "type": "object",
    "meta:status": "V2.0.0",
    "oneOf": [
        {
            "$ref": "continuous.json"
        },
        {
            "$ref": "equal.json"
        },
        {
            "$ref": "in_periodic.json"
        },
        {
            "$ref": "multi_enum.json"
        }
    ]
}

```

Commit 8f91237 solves this issue.

2 - Some of my schemas are as well only defined by `patternProperties`:

```json
{
    "$schema": "http://json-schema.org/draft-07/schema#",
    "$id": "...",
    "title": "....",
    "description": "...",
    "meta:status": "V2.0.0",
    "type": "object",
    "patternProperties": {
        "^[A-Za-z_][A-Za-z0-9_]*$": {
            "required": [
                "type"
            ],
            "type": "object",
            "oneOf": [
                {
                    "$ref": "ref1.json"
                },
                {
                    "$ref": "ref2.json"
                }
            ]
        }
    },
    "additionalProperties": false
}
```

Commit 52da75d solves this issue.

3 - Some of schemas contains array with `join-type` items:

```json

"children": {
            "type": "array",
            "items": {
                "oneOf": [
                    {
                        "$ref": "leaf.json"
                    },
                    {
                        "$ref": "node.json"
                    }
                ]
            },
            "minItems": 1
        }

```

Commit 930332f solves this issue
