### PR TITLE
Resolves #64. Worked out path logic

### DIFF
--- a/lib/header.js
+++ b/lib/header.js
@@ -105,7 +105,14 @@ function headers(schema, indir, filename, docs, outdir) {
   this.myheaders.push(new Header('Identifiable', link(indir, filename, this.doclinks['id']), isIdentifiable(schema)));
   this.myheaders.push(new Header('Custom Properties', link(indir, filename, this.doclinks['custom']), props.custom));
   this.myheaders.push(new Header('Additional Properties', link(indir, filename, this.doclinks['additional']), schema.additionalProperties===false ? 'Forbidden' : 'Permitted'));
-  this.myheaders.push(new Header('Defined In', undefined, props.original, props.original));
+
+  // we need to create "directory path", from this file (filename) to the "props.original" location.
+  // they _could_ be in different directories.
+  var thisFileRelativePath = path.dirname(filename.substring(indir.length + path.sep.length)); // strip off the /full-path
+  // now create a relative path from "this" file's dir to dir of props.original
+  var fromToPath = path.relative(thisFileRelativePath,path.dirname(props.original));
+
+  this.myheaders.push(new Header('Defined In', undefined, props.original, path.join(fromToPath, path.basename(props.original))));
 
   this.render = function() {
     var buf = '';


### PR DESCRIPTION
This resolves #64.

The relative path to the "defined" schema is required, to create a link.
The schema referred to is perhaps always the same, but did not assume it would be so created lgic to generate a relative path regardless.