### PR TITLE
Updated npm install instructions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ You can conveniently use the JSON Schema Markdown Tools from `npm`. This makes i
 
 ```json
   "devDependencies": {
-    "jsonschema2md": "^1.0.6"
+    "@adobe/jsonschema2md": "^1.0.6"
   }
 ```
 
@@ -74,7 +74,7 @@ Then add the following to the `"scripts"` section of your `package.json` and ada
 }
 ```
 
-If you run `npm install` before running `npm run prepare`, `npm` will install the `jsonschema2md` in a `node_modules/.bin` path, even if you did not install the JSON Schema Markdown beforehand.
+If you run `npm install` before running `npm run prepare`, `npm` will install the `@adobe/jsonschema2md` in a `node_modules/.bin` path, even if you did not install the JSON Schema Markdown beforehand.
 
 ## Tests
 


### PR DESCRIPTION
The module is published on npm under `@adobe` and as such needs to be references as `@adobe/jsonschema2md` for `npm install` or `yarn` to actually find the module on npm.