### PR TITLE
#64 bug/defined in path

### DIFF
--- a/examples/docs/subdir/subdir.schema.md
+++ b/examples/docs/subdir/subdir.schema.md
@@ -13,7 +13,7 @@ A schema in a sub directory
 
 | [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
 |-------------------------------|------------|---------------------------|--------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir/subdir.schema.json) |
+| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir.schema.json) |
 
 
 **All** of the following *requirements* need to be fulfilled.

--- a/lib/header.js
+++ b/lib/header.js
@@ -105,7 +105,14 @@ function headers(schema, indir, filename, docs, outdir) {
   this.myheaders.push(new Header('Identifiable', link(indir, filename, this.doclinks['id']), isIdentifiable(schema)));
   this.myheaders.push(new Header('Custom Properties', link(indir, filename, this.doclinks['custom']), props.custom));
   this.myheaders.push(new Header('Additional Properties', link(indir, filename, this.doclinks['additional']), schema.additionalProperties===false ? 'Forbidden' : 'Permitted'));
-  this.myheaders.push(new Header('Defined In', undefined, props.original, props.original));
+
+  // we need to create "directory path", from this file (filename) to the "props.original" location.
+  // they _could_ be in different directories.
+  var thisFileRelativePath = path.dirname(filename.substring(indir.length + path.sep.length)); // strip off the /full-path
+  // now create a relative path from "this" file's dir to dir of props.original
+  var fromToPath = path.relative(thisFileRelativePath,path.dirname(props.original));
+
+  this.myheaders.push(new Header('Defined In', undefined, props.original, path.join(fromToPath, path.basename(props.original))));
 
   this.render = function() {
     var buf = '';

--- a/lib/header.js
+++ b/lib/header.js
@@ -105,14 +105,7 @@ function headers(schema, indir, filename, docs, outdir) {
   this.myheaders.push(new Header('Identifiable', link(indir, filename, this.doclinks['id']), isIdentifiable(schema)));
   this.myheaders.push(new Header('Custom Properties', link(indir, filename, this.doclinks['custom']), props.custom));
   this.myheaders.push(new Header('Additional Properties', link(indir, filename, this.doclinks['additional']), schema.additionalProperties===false ? 'Forbidden' : 'Permitted'));
-
-  // we need to create "directory path", from this file (filename) to the "props.original" location.
-  // they _could_ be in different directories.
-  var thisFileRelativePath = path.dirname(filename.substring(indir.length + path.sep.length)); // strip off the /full-path
-  // now create a relative path from "this" file's dir to dir of props.original
-  var fromToPath = path.relative(thisFileRelativePath,path.dirname(props.original));
-
-  this.myheaders.push(new Header('Defined In', undefined, props.original, path.join(fromToPath, path.basename(props.original))));
+  this.myheaders.push(new Header('Defined In', undefined, props.original, path.basename(props.original)));
 
   this.render = function() {
     var buf = '';

--- a/spec/lib/header.spec.js
+++ b/spec/lib/header.spec.js
@@ -45,4 +45,19 @@ describe('Headers Integration Test', () => {
     expect(h.render()).toEqual(result);
   });
 
+  it('Markdown links should be correct when schema is in a subdir.', () => {
+    const schema = {
+      additionalProperties: true,
+      'meta:extensible': false,
+      properties: { 'foo':'bar', 'bar': 'baz' }
+    };
+
+    const h = headers(schema, '/home/lars', '/home/lars/some/deep/path/complex.schema.json');
+
+    const result = `| Abstract | Extensible | Status | Identifiable | Custom Properties | Additional Properties | Defined In |
+|----------|------------|--------|--------------|-------------------|-----------------------|------------|
+| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [some/deep/path/complex.schema.json](complex.schema.json) |`;
+    expect(h.render()).toEqual(result);
+  });
+
 });


### PR DESCRIPTION
* #64 added test in `header.spec.js`
* Simplified the logic on the basis that the schema is always for the current directory.