### PR TITLE
feat: Apply prettier to generated markdown files for improved formatting

### DIFF
--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -1,33 +1,28 @@
-
-
- # Readme
-
-
+# Readme
 
 ## /
 
-* [Abstract](./abstract.schema.md) – `https://example.com/schemas/abstract` (Unknown)
-* [Arrays](./arrays.schema.md) – `https://example.com/schemas/arrays` (Unknown)
-* [Complex References ](./complex.schema.md) – `https://example.com/schemas/complex` (Unknown)
-* [Constant Types](./constants.schema.md) – `https://example.com/schemas/constants` (Unknown)
-* [Custom](./custom.schema.md) – `https://example.com/schemas/custom` (Unknown)
-* [Deeply Extending](./deepextending.schema.md) – `https://example.com/schemas/deepextending` (Unknown)
-* [Definitions](./definitions.schema.md) – `https://example.com/schemas/definitions` (Unknown)
-* [Enumerated ](./enums.schema.md) – `https://example.com/schemas/enums` (Unknown)
-* [Example](./example.schema.md) – `https://example.com/schemas/example` (Unknown)
-* [Examples](./examples.schema.md) – `https://example.com/schemas/examples` (Unknown)
-* [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
-* [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
-* [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
-* [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
-* [Nested Object](./nestedobj.schema.md) – `https://example.com/schemas/nestedobject` (Unknown)
-* [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
-* [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
-* [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
-* [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)
-* [Type Arrays](./typearrays.schema.md) – `https://example.com/schemas/typearrays` (Unknown)
+- [Abstract](./abstract.schema.md) – `https://example.com/schemas/abstract` (Unknown)
+- [Arrays](./arrays.schema.md) – `https://example.com/schemas/arrays` (Unknown)
+- [Complex References ](./complex.schema.md) – `https://example.com/schemas/complex` (Unknown)
+- [Constant Types](./constants.schema.md) – `https://example.com/schemas/constants` (Unknown)
+- [Custom](./custom.schema.md) – `https://example.com/schemas/custom` (Unknown)
+- [Deeply Extending](./deepextending.schema.md) – `https://example.com/schemas/deepextending` (Unknown)
+- [Definitions](./definitions.schema.md) – `https://example.com/schemas/definitions` (Unknown)
+- [Enumerated ](./enums.schema.md) – `https://example.com/schemas/enums` (Unknown)
+- [Example](./example.schema.md) – `https://example.com/schemas/example` (Unknown)
+- [Examples](./examples.schema.md) – `https://example.com/schemas/examples` (Unknown)
+- [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
+- [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
+- [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+- [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
+- [Nested Object](./nestedobj.schema.md) – `https://example.com/schemas/nestedobject` (Unknown)
+- [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
+- [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
+- [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
+- [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)
+- [Type Arrays](./typearrays.schema.md) – `https://example.com/schemas/typearrays` (Unknown)
 
 ## /subdir/
 
-* [Subdir](./subdir/subdir.schema.md) – `https://example.com/schemas/subdir/subdir` (Unknown)
-
+- [Subdir](./subdir/subdir.schema.md) – `https://example.com/schemas/subdir/subdir` (Unknown)

--- a/examples/docs/abstract.schema.md
+++ b/examples/docs/abstract.schema.md
@@ -11,17 +11,17 @@ https://example.com/schemas/abstract
 
 This is an abstract schema. It has `definitions`, but does not declare any properties
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [abstract.schema.json](abstract.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                   |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------- |
+| Cannot be instantiated     | Yes        | Experimental           | No           | Forbidden         | Permitted             | [abstract.schema.json](abstract.schema.json) |
 
 # Abstract Definitions
 
-| Property | Type | Group |
-|----------|------|-------|
-| [bar](#bar) | `string` | `https://example.com/schemas/abstract#/definitions/second` |
-| [foo](#foo) | `string` | `https://example.com/schemas/abstract#/definitions/first` |
-| [nonfoo](#nonfoo) | `const` | `https://example.com/schemas/abstract#/definitions/first` |
+| Property          | Type     | Group                                                      |
+| ----------------- | -------- | ---------------------------------------------------------- |
+| [bar](#bar)       | `string` | `https://example.com/schemas/abstract#/definitions/second` |
+| [foo](#foo)       | `string` | `https://example.com/schemas/abstract#/definitions/first`  |
+| [nonfoo](#nonfoo) | `const`  | `https://example.com/schemas/abstract#/definitions/first`  |
 
 ## bar
 
@@ -29,20 +29,13 @@ A unique identifier given to every addressable thing.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
-
 
 ## foo
 
@@ -50,20 +43,13 @@ A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
-
 
 ## nonfoo
 
@@ -71,16 +57,12 @@ This is not foo.
 
 `nonfoo`
 
-* is optional
-* type: `const`
-* defined in this schema
+- is optional
+- type: `const`
+- defined in this schema
 
 The value of this property **must** be equal to:
 
 ```json
 false
 ```
-
-
-
-

--- a/examples/docs/arrays.schema.md
+++ b/examples/docs/arrays.schema.md
@@ -11,24 +11,24 @@ https://example.com/schemas/arrays
 
 This is an example schema with examples for multiple array types and their constraints.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [arrays.schema.json](arrays.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [arrays.schema.json](arrays.schema.json) |
 
 # Arrays Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [JoinTypelist](#jointypelist) | `array` | Optional  | No | Arrays (this schema) |
-| [boollist](#boollist) | `boolean[]` | Optional  | No | Arrays (this schema) |
-| [coordinatelist](#coordinatelist) | `number[][]` | Optional  | No | Arrays (this schema) |
-| [intlist](#intlist) | `integer[]` | Optional  | No | Arrays (this schema) |
-| [list](#list) | `string[]` | Optional  | No | Arrays (this schema) |
-| [listlist](#listlist) | `array[]` | Optional  | No | Arrays (this schema) |
-| [numlist](#numlist) | `number[]` | Optional  | No | Arrays (this schema) |
-| [objectlist](#objectlist) | `object[]` | Optional  | No | Arrays (this schema) |
-| [stringlistlist](#stringlistlist) | `string[][]` | Optional  | No | Arrays (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                          | Type         | Required   | Nullable | Defined by                                 |
+| --------------------------------- | ------------ | ---------- | -------- | ------------------------------------------ |
+| [JoinTypelist](#jointypelist)     | `array`      | Optional   | No       | Arrays (this schema)                       |
+| [boollist](#boollist)             | `boolean[]`  | Optional   | No       | Arrays (this schema)                       |
+| [coordinatelist](#coordinatelist) | `number[][]` | Optional   | No       | Arrays (this schema)                       |
+| [intlist](#intlist)               | `integer[]`  | Optional   | No       | Arrays (this schema)                       |
+| [list](#list)                     | `string[]`   | Optional   | No       | Arrays (this schema)                       |
+| [listlist](#listlist)             | `array[]`    | Optional   | No       | Arrays (this schema)                       |
+| [numlist](#numlist)               | `number[]`   | Optional   | No       | Arrays (this schema)                       |
+| [objectlist](#objectlist)         | `object[]`   | Optional   | No       | Arrays (this schema)                       |
+| [stringlistlist](#stringlistlist) | `string[][]` | Optional   | No       | Arrays (this schema)                       |
+| `*`                               | any          | Additional | Yes      | this schema _allows_ additional properties |
 
 ## JoinTypelist
 
@@ -36,31 +36,25 @@ An array of simple objects
 
 `JoinTypelist`
 
-* is optional
-* type: `array`
-* defined in this schema
+- is optional
+- type: `array`
+- defined in this schema
 
 ### JoinTypelist Type
-
 
 Array type: `array`
 
 All items must be of the type:
 
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `foo`    | string | Optional |
 
 #### foo
 
@@ -68,18 +62,12 @@ A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
 
 ##### foo Example
 
@@ -87,20 +75,13 @@ A simple string.
 hello
 ```
 
-
-
-
 #### Condition 2
-
 
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `bar`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `bar`    | string | Optional |
 
 #### bar
 
@@ -108,18 +89,12 @@ A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### bar Type
 
-
 `string`
-
-
-
-
-
 
 ##### bar Example
 
@@ -127,41 +102,22 @@ A simple string.
 world
 ```
 
-
-
-
-  
-
-
-
-
-
-
-
 ## boollist
 
 This is an array
 
 `boollist`
 
-* is optional
-* type: `boolean[]`
-* at least `1` items in the array
-* defined in this schema
+- is optional
+- type: `boolean[]`
+- at least `1` items in the array
+- defined in this schema
 
 ### boollist Type
 
-
 Array type: `boolean[]`
 
-All items must be of the type:
-`boolean`
-
-
-
-
-
-
+All items must be of the type: `boolean`
 
 ## coordinatelist
 
@@ -169,35 +125,21 @@ This is an array of coordinates in three-dimensional space.
 
 `coordinatelist`
 
-* is optional
-* type: `number[][]` (nested array)
-* no more than `10` items in the array
-* defined in this schema
+- is optional
+- type: `number[][]` (nested array)
+- no more than `10` items in the array
+- defined in this schema
 
 ### coordinatelist Type
 
-
 Nested array type: `number[]`
 
+All items must be of the type: `number`
 
+- minimum value: `0`
+- maximum value: `10`
 
-All items must be of the type:
-`number`
-
-* minimum value: `0`
-* maximum value: `10`
-
-
-
-
-  
 A coordinate, specified by `x`, `y`, and `z` values
-
-
-
-
-
-
 
 ## intlist
 
@@ -205,27 +147,16 @@ This is an array
 
 `intlist`
 
-* is optional
-* type: `integer[]`
-* between `1` and `10` items in the array
-* defined in this schema
+- is optional
+- type: `integer[]`
+- between `1` and `10` items in the array
+- defined in this schema
 
 ### intlist Type
 
-
 Array type: `integer[]`
 
-All items must be of the type:
-`integer`
-
-
-
-
-
-
-
-
-
+All items must be of the type: `integer`
 
 ## list
 
@@ -233,26 +164,15 @@ This is an array
 
 `list`
 
-* is optional
-* type: `string[]`
-* defined in this schema
+- is optional
+- type: `string[]`
+- defined in this schema
 
 ### list Type
 
-
 Array type: `string[]`
 
-All items must be of the type:
-`string`
-
-
-
-
-
-
-
-
-
+All items must be of the type: `string`
 
 ## listlist
 
@@ -260,23 +180,13 @@ This is an array of arrays
 
 `listlist`
 
-* is optional
-* type: `array[]` (nested array)
-* defined in this schema
+- is optional
+- type: `array[]` (nested array)
+- defined in this schema
 
 ### listlist Type
 
-
 Nested array type: `array`
-
-
-
-
-
-
-
-
-
 
 ## numlist
 
@@ -284,27 +194,18 @@ This is an array
 
 `numlist`
 
-* is optional
-* type: `number[]`
-* no more than `10` items in the array
-* defined in this schema
+- is optional
+- type: `number[]`
+- no more than `10` items in the array
+- defined in this schema
 
 ### numlist Type
 
-
 Array type: `number[]`
 
-All items must be of the type:
-`number`
+All items must be of the type: `number`
 
-* minimum value: `10`
-
-
-
-
-
-
-
+- minimum value: `10`
 
 ## objectlist
 
@@ -312,25 +213,20 @@ An array of simple objects
 
 `objectlist`
 
-* is optional
-* type: `object[]`
-* defined in this schema
+- is optional
+- type: `object[]`
+- defined in this schema
 
 ### objectlist Type
 
-
 Array type: `object[]`
 
-All items must be of the type:
-`object` with following properties:
+All items must be of the type: `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `a`| string | **Required** |
-| `b`| integer | Optional |
-
-
+| Property | Type    | Required     |
+| -------- | ------- | ------------ |
+| `a`      | string  | **Required** |
+| `b`      | integer | Optional     |
 
 #### a
 
@@ -338,21 +234,12 @@ The a property
 
 `a`
 
-* is **required**
-* type: `string`
+- is **required**
+- type: `string`
 
 ##### a Type
 
-
 `string`
-
-
-
-
-
-
-
-
 
 #### b
 
@@ -360,27 +247,12 @@ The b property
 
 `b`
 
-* is optional
-* type: `integer`
+- is optional
+- type: `integer`
 
 ##### b Type
 
-
 `integer`
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 ## stringlistlist
 
@@ -388,27 +260,12 @@ This is an array of arrays of strings
 
 `stringlistlist`
 
-* is optional
-* type: `string[][]` (nested array)
-* defined in this schema
+- is optional
+- type: `string[][]` (nested array)
+- defined in this schema
 
 ### stringlistlist Type
 
-
 Nested array type: `string[]`
 
-
-
-All items must be of the type:
-`string`
-
-
-
-
-
-
-
-
-
-
-
+All items must be of the type: `string`

--- a/examples/docs/complex.schema.md
+++ b/examples/docs/complex.schema.md
@@ -3,7 +3,7 @@ template: reference
 foo: bar
 ---
 
-# Complex References  Schema
+# Complex References Schema
 
 ```
 https://example.com/schemas/complex
@@ -11,29 +11,29 @@ https://example.com/schemas/complex
 
 This is an example schema that uses types defined in other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [complex.schema.json](complex.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [complex.schema.json](complex.schema.json) |
+
 ## Schema Hierarchy
 
-* Complex References  `https://example.com/schemas/complex`
-  * [Abstract](abstract.schema.md) `https://example.com/schemas/abstract`
-  * [Simple](simple.schema.md) `https://example.com/schemas/simple`
+- Complex References `https://example.com/schemas/complex`
+  - [Abstract](abstract.schema.md) `https://example.com/schemas/abstract`
+  - [Simple](simple.schema.md) `https://example.com/schemas/simple`
 
+# Complex References Properties
 
-# Complex References  Properties
-
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [and](#and) | complex | Optional  | No | Complex References  (this schema) |
-| [or](#or) | complex | Optional  | No | Complex References  (this schema) |
-| [refabstract](#refabstract) | `object` | **Required**  | No | Complex References  (this schema) |
-| [reflist](#reflist) | Simple | Optional  | No | Complex References  (this schema) |
-| [refnamed](#refnamed) | Simple | Optional  | No | Complex References  (this schema) |
-| [xor](#xor) | complex | Optional  | No | Complex References  (this schema) |
-| `int.*` | `integer` | Pattern | No | Complex References  (this schema) |
-| `str.*` | `string` | Pattern | No | Complex References  (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                    | Type      | Required     | Nullable | Defined by                                 |
+| --------------------------- | --------- | ------------ | -------- | ------------------------------------------ |
+| [and](#and)                 | complex   | Optional     | No       | Complex References (this schema)           |
+| [or](#or)                   | complex   | Optional     | No       | Complex References (this schema)           |
+| [refabstract](#refabstract) | `object`  | **Required** | No       | Complex References (this schema)           |
+| [reflist](#reflist)         | Simple    | Optional     | No       | Complex References (this schema)           |
+| [refnamed](#refnamed)       | Simple    | Optional     | No       | Complex References (this schema)           |
+| [xor](#xor)                 | complex   | Optional     | No       | Complex References (this schema)           |
+| `int.*`                     | `integer` | Pattern      | No       | Complex References (this schema)           |
+| `str.*`                     | `string`  | Pattern      | No       | Complex References (this schema)           |
+| `*`                         | any       | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## and
 
@@ -41,36 +41,25 @@ Number in a range
 
 `and`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### and Type
 
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
 `number`
 
-* maximum value: `10`
-
+- maximum value: `10`
 
 #### Requirement 2
 
-
 `number`
 
-* minimum value: `0`
-
-
-
-
-
-
+- minimum value: `0`
 
 ## or
 
@@ -78,58 +67,40 @@ String or number…
 
 `or`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### or Type
 
-
-**Any** following *options* needs to be fulfilled.
-
+**Any** following _options_ needs to be fulfilled.
 
 #### Option 1
 
-
 `string`
-
-
-
 
 #### Option 2
 
-
 `number`
 
-* minimum value: `0`
-
-
-
-
-
-
+- minimum value: `0`
 
 ## refabstract
 
-
 `refabstract`
 
-* is **required**
-* type: `object`
-* defined in this schema
+- is **required**
+- type: `object`
+- defined in this schema
 
 ### refabstract Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-| `nonfoo`| boolean | Optional |
-
-
+| Property | Type    | Required |
+| -------- | ------- | -------- |
+| `foo`    | string  | Optional |
+| `nonfoo` | boolean | Optional |
 
 #### foo
 
@@ -137,21 +108,12 @@ A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
-
-
-
 
 #### nonfoo
 
@@ -159,8 +121,8 @@ This is not foo.
 
 `nonfoo`
 
-* is optional
-* type: `const`
+- is optional
+- type: `const`
 
 The value of this property **must** be equal to:
 
@@ -168,56 +130,33 @@ The value of this property **must** be equal to:
 false
 ```
 
-
-
-
-
-
-
-
-
-
 ## reflist
-
 
 `reflist`
 
-* is optional
-* type: Simple
-* defined in this schema
+- is optional
+- type: Simple
+- defined in this schema
 
 ### reflist Type
-
 
 Array type: Simple
 
 All items must be of the type:
-* [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
-
-
-
-
-
-
+- [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
 ## refnamed
 
-
 `refnamed`
 
-* is optional
-* type: Simple
-* defined in this schema
+- is optional
+- type: Simple
+- defined in this schema
 
 ### refnamed Type
 
-
-* [Simple](simple.schema.md) – `https://example.com/schemas/simple`
-
-
-
-
+- [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
 ## xor
 
@@ -225,75 +164,50 @@ Exclusive choice.
 
 `xor`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### xor Type
 
-
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `number`
 
-* maximum value: `0`
-
+- maximum value: `0`
 
 #### Condition 2
 
-
 `number`
 
-* minimum value: `10`
-
-
-
-
-
-
+- minimum value: `10`
 
 ## Pattern: `int.*`
-Applies to all properties that match the regular expression `int.*`
 
+Applies to all properties that match the regular expression `int.*`
 
 `int.*`
 
-* is a property pattern
-* type: `integer`
-* defined in this schema
+- is a property pattern
+- type: `integer`
+- defined in this schema
 
-### Pattern int.* Type
-
+### Pattern int.\* Type
 
 `integer`
 
-
-
-
-
-
-
 ## Pattern: `str.*`
-Applies to all properties that match the regular expression `str.*`
 
+Applies to all properties that match the regular expression `str.*`
 
 `str.*`
 
-* is a property pattern
-* type: `string`
-* defined in this schema
+- is a property pattern
+- type: `string`
+- defined in this schema
 
-### Pattern str.* Type
-
+### Pattern str.\* Type
 
 `string`
-
-
-
-
-
-

--- a/examples/docs/constants.schema.md
+++ b/examples/docs/constants.schema.md
@@ -11,16 +11,16 @@ https://example.com/schemas/constants
 
 This is an example schema with examples for properties with constant values
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [constants.schema.json](constants.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [constants.schema.json](constants.schema.json) |
 
 # Constant Types Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [hello](#hello) | `const` | **Required**  | No | Constant Types (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property        | Type    | Required     | Nullable | Defined by                                 |
+| --------------- | ------- | ------------ | -------- | ------------------------------------------ |
+| [hello](#hello) | `const` | **Required** | No       | Constant Types (this schema)               |
+| `*`             | any     | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## hello
 
@@ -28,16 +28,12 @@ A simple string, without strong constraints.
 
 `hello`
 
-* is **required**
-* type: `const`
-* defined in this schema
+- is **required**
+- type: `const`
+- defined in this schema
 
 The value of this property **must** be equal to:
 
 ```json
 "World"
 ```
-
-
-
-

--- a/examples/docs/custom.schema.md
+++ b/examples/docs/custom.schema.md
@@ -9,19 +9,20 @@ foo: bar
 https://example.com/schemas/custom
 ```
 
-This is an extensible schema. It has `definitions`, that can be used in other schemas. Additionally, it allows custom properties.
+This is an extensible schema. It has `definitions`, that can be used in other schemas. Additionally, it allows custom
+properties.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | No | Allowed | Permitted | [custom.schema.json](custom.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | No           | Allowed           | Permitted             | [custom.schema.json](custom.schema.json) |
 
 # Custom Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | Optional  | No | Custom (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Custom (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required   | Nullable | Defined by                                 |
+| ----------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | Optional   | No       | Custom (this schema)                       |
+| [foo](#foo) | `string` | Optional   | No       | Custom (this schema)                       |
+| `*`         | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## bar
 
@@ -29,20 +30,13 @@ A unique identifier given to every addressable thing.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
-
 
 ## foo
 
@@ -50,39 +44,24 @@ A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
 
-
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
-
+- []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
 
 #### Requirement 2
 
-
-* []() – `#/definitions/first`
-
+- []() – `#/definitions/first`
 
 #### Requirement 3
 
-
-* []() – `#/definitions/second`
-
+- []() – `#/definitions/second`

--- a/examples/docs/deepextending.schema.md
+++ b/examples/docs/deepextending.schema.md
@@ -11,28 +11,28 @@ https://example.com/schemas/deepextending
 
 This is an extending schema. It is extending another extending schema. It pulls `definitions` from other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [deepextending.schema.json](deepextending.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                             |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------------ |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [deepextending.schema.json](deepextending.schema.json) |
+
 ## Schema Hierarchy
 
-* Deeply Extending `https://example.com/schemas/deepextending`
-  * [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
-  * [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
-  * [Extending](extending.schema.md) `https://example.com/schemas/extending`
-
+- Deeply Extending `https://example.com/schemas/deepextending`
+  - [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
+  - [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
+  - [Extending](extending.schema.md) `https://example.com/schemas/extending`
 
 # Deeply Extending Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | [Definitions](definitions.schema.md#id) |
-| [bar](#bar) | `string` | Optional  | No | [Extensible](extensible.schema.md#bar) |
-| [baz](#baz) | `string` | Optional  | No | [Extending](extending.schema.md#baz) |
-| [hey](#hey) | `string` | Optional  | No | Deeply Extending (this schema) |
-| [id](#id-1) | `string` | Optional  | No | [Definitions](definitions.schema.md#id-1) |
-| [meta:id](#metaid) | `string` | Optional  | No | [Definitions](definitions.schema.md#metaid) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required   | Nullable | Defined by                                  |
+| ------------------ | -------- | ---------- | -------- | ------------------------------------------- |
+| [@id](#id)         | `string` | Optional   | No       | [Definitions](definitions.schema.md#id)     |
+| [bar](#bar)        | `string` | Optional   | No       | [Extensible](extensible.schema.md#bar)      |
+| [baz](#baz)        | `string` | Optional   | No       | [Extending](extending.schema.md#baz)        |
+| [hey](#hey)        | `string` | Optional   | No       | Deeply Extending (this schema)              |
+| [id](#id-1)        | `string` | Optional   | No       | [Definitions](definitions.schema.md#id-1)   |
+| [meta:id](#metaid) | `string` | Optional   | No       | [Definitions](definitions.schema.md#metaid) |
+| `*`                | any      | Additional | Yes      | this schema _allows_ additional properties  |
 
 ## @id
 
@@ -40,21 +40,15 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## bar
 
@@ -62,19 +56,13 @@ A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in [Extensible](extensible.schema.md#bar)
+- is optional
+- type: `string`
+- defined in [Extensible](extensible.schema.md#bar)
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -86,28 +74,21 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## baz
+
 ### BAAAZ!
 
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
 
-* is optional
-* type: `string`
-* defined in [Extending](extending.schema.md#baz)
+- is optional
+- type: `string`
+- defined in [Extending](extending.schema.md#baz)
 
 ### baz Type
 
-
 `string`
-
-
-
-
-
 
 ### baz Example
 
@@ -115,27 +96,19 @@ This property has a unique name to demonstrate it's uniqueness.
 "I'm just a humble example"
 ```
 
-
 ## hey
 
 A unique identifier given to every addressable thing.
 
 `hey`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### hey Type
 
-
 `string`
-
-
-
-
-
-
 
 ## id
 
@@ -143,21 +116,15 @@ A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id-1)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
 
@@ -165,46 +132,30 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#metaid)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://example.com/schemas/extensible#/definitions/second`
-
+- []() – `https://example.com/schemas/extensible#/definitions/second`
 
 #### Requirement 2
 
-
-* []() – `https://example.com/schemas/definitions#/definitions/myid`
-
+- []() – `https://example.com/schemas/definitions#/definitions/myid`
 
 #### Requirement 3
 
-
-* []() – `https://example.com/schemas/extending#/definitions/third`
-
+- []() – `https://example.com/schemas/extending#/definitions/third`
 
 #### Requirement 4
 
-
-* []() – `#/definitions/fourth`
-
+- []() – `#/definitions/fourth`

--- a/examples/docs/definitions.schema.md
+++ b/examples/docs/definitions.schema.md
@@ -27,19 +27,18 @@ aks.
 
 > Everything is better with a quote.
 
-
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [definitions.schema.json](definitions.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [definitions.schema.json](definitions.schema.json) |
 
 # Definitions Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | **Required**  | No | Definitions (this schema) |
-| [id](#id-1) | `string` | **Required**  | No | Definitions (this schema) |
-| [meta:id](#metaid) | `string` | Optional  | No | Definitions (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required     | Nullable | Defined by                                 |
+| ------------------ | -------- | ------------ | -------- | ------------------------------------------ |
+| [@id](#id)         | `string` | **Required** | No       | Definitions (this schema)                  |
+| [id](#id-1)        | `string` | **Required** | No       | Definitions (this schema)                  |
+| [meta:id](#metaid) | `string` | Optional     | No       | Definitions (this schema)                  |
+| `*`                | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## @id
 
@@ -47,21 +46,15 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## id
 
@@ -69,21 +62,15 @@ A unique identifier given to every addressable thing.
 
 `id`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
 
@@ -91,28 +78,18 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/myid`
-
+- []() – `#/definitions/myid`

--- a/examples/docs/enums.schema.md
+++ b/examples/docs/enums.schema.md
@@ -3,7 +3,7 @@ template: reference
 foo: bar
 ---
 
-# Enumerated  Schema
+# Enumerated Schema
 
 ```
 https://example.com/schemas/enums
@@ -11,17 +11,17 @@ https://example.com/schemas/enums
 
 This is an example schema with examples for properties with enum values
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [enums.schema.json](enums.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                             |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [enums.schema.json](enums.schema.json) |
 
-# Enumerated  Properties
+# Enumerated Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [hello](#hello) | `enum` | **Required**  | No | Enumerated  (this schema) |
-| [nested](#nested) | `object` | Optional  | No | Enumerated  (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property          | Type     | Required     | Nullable | Defined by                                 |
+| ----------------- | -------- | ------------ | -------- | ------------------------------------------ |
+| [hello](#hello)   | `enum`   | **Required** | No       | Enumerated (this schema)                   |
+| [nested](#nested) | `object` | Optional     | No       | Enumerated (this schema)                   |
+| `*`               | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## hello
 
@@ -29,43 +29,38 @@ A simple string. Pick a value.
 
 `hello`
 
-* is **required**
-* type: `enum`
-* defined in this schema
+- is **required**
+- type: `enum`
+- defined in this schema
 
 The value of this property **must** be equal to one of the [known values below](#hello-known-values).
 
 ### hello Known Values
-| Value | Description |
-|-------|-------------|
-| `World` |  |
-| `Welt` |  |
 
-
-
+| Value   | Description |
+| ------- | ----------- |
+| `World` |             |
+| `Welt`  |             |
 
 ## nested
+
 ### Enumerated (Nested)
 
 This is an example schema with examples for properties of nested objects with enum values
 
 `nested`
 
-* is optional
-* type: `object`
-* defined in this schema
+- is optional
+- type: `object`
+- defined in this schema
 
 ### nested Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `test`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `test`   | string | Optional |
 
 #### test
 
@@ -73,22 +68,15 @@ A simple string. Pick a value.
 
 `test`
 
-* is optional
-* type: `enum`
+- is optional
+- type: `enum`
 
 The value of this property **must** be equal to one of the [known values below](#nested-known-values).
 
 ##### test Known Values
-| Value | Description |
-|-------|-------------|
-| `nested` |  |
-| `object` |  |
-| `works` |  |
 
-
-
-
-
-
-
-
+| Value    | Description |
+| -------- | ----------- |
+| `nested` |             |
+| `object` |             |
+| `works`  |             |

--- a/examples/docs/example.schema.md
+++ b/examples/docs/example.schema.md
@@ -11,11 +11,12 @@ https://example.com/schemas/example
 
 This is an example schema with examples. Too many examples? There can never be too many examples!
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [example.schema.json](example.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [example.schema.json](example.schema.json) |
 
 ## Example Example
+
 ```json
 {
   "foo": "bar",
@@ -25,11 +26,11 @@ This is an example schema with examples. Too many examples? There can never be t
 
 # Example Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | Optional  | No | Example (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Example (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required   | Nullable | Defined by                                 |
+| ----------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | Optional   | No       | Example (this schema)                      |
+| [foo](#foo) | `string` | Optional   | No       | Example (this schema)                      |
+| `*`         | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## bar
 
@@ -37,19 +38,13 @@ A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -61,31 +56,22 @@ A simple string.
 "baz"
 ```
 
-
-
 ## foo
 
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/examples/docs/examples.schema.md
+++ b/examples/docs/examples.schema.md
@@ -9,11 +9,11 @@ foo: bar
 https://example.com/schemas/examples
 ```
 
-This is an example schema with *multiple* examples. Too many examples? There can never be too many examples!
+This is an example schema with _multiple_ examples. Too many examples? There can never be too many examples!
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [examples.schema.json](examples.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                   |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [examples.schema.json](examples.schema.json) |
 
 ## Examples Examples
 
@@ -31,14 +31,13 @@ This is an example schema with *multiple* examples. Too many examples? There can
 }
 ```
 
-
 # Examples Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | **Required**  | No | Examples (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Examples (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required     | Nullable | Defined by                                 |
+| ----------- | -------- | ------------ | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | **Required** | No       | Examples (this schema)                     |
+| [foo](#foo) | `string` | Optional     | No       | Examples (this schema)                     |
+| `*`         | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## bar
 
@@ -46,19 +45,13 @@ A simple string.
 
 `bar`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -70,31 +63,22 @@ A simple string.
 "baz"
 ```
 
-
-
 ## foo
 
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/examples/docs/extending.schema.md
+++ b/examples/docs/extending.schema.md
@@ -11,26 +11,26 @@ https://example.com/schemas/extending
 
 This is an extending schema. It pulls `definitions` from other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [extending.schema.json](extending.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [extending.schema.json](extending.schema.json) |
+
 ## Schema Hierarchy
 
-* Extending `https://example.com/schemas/extending`
-  * [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
-  * [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
-
+- Extending `https://example.com/schemas/extending`
+  - [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
+  - [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
 
 # Extending Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | [Definitions](definitions.schema.md#id) |
-| [bar](#bar) | `string` | Optional  | No | [Extensible](extensible.schema.md#bar) |
-| [baz](#baz) | `string` | Optional  | No | Extending (this schema) |
-| [id](#id-1) | `string` | Optional  | No | [Definitions](definitions.schema.md#id-1) |
-| [meta:id](#metaid) | `string` | Optional  | No | [Definitions](definitions.schema.md#metaid) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required   | Nullable | Defined by                                  |
+| ------------------ | -------- | ---------- | -------- | ------------------------------------------- |
+| [@id](#id)         | `string` | Optional   | No       | [Definitions](definitions.schema.md#id)     |
+| [bar](#bar)        | `string` | Optional   | No       | [Extensible](extensible.schema.md#bar)      |
+| [baz](#baz)        | `string` | Optional   | No       | Extending (this schema)                     |
+| [id](#id-1)        | `string` | Optional   | No       | [Definitions](definitions.schema.md#id-1)   |
+| [meta:id](#metaid) | `string` | Optional   | No       | [Definitions](definitions.schema.md#metaid) |
+| `*`                | any      | Additional | Yes      | this schema _allows_ additional properties  |
 
 ## @id
 
@@ -38,21 +38,15 @@ An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## bar
 
@@ -60,19 +54,13 @@ A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in [Extensible](extensible.schema.md#bar)
+- is optional
+- type: `string`
+- defined in [Extensible](extensible.schema.md#bar)
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -84,28 +72,21 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## baz
+
 ### BAAAZ!
 
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### baz Type
 
-
 `string`
-
-
-
-
-
 
 ### baz Example
 
@@ -113,28 +94,21 @@ This property has a unique name to demonstrate it's uniqueness.
 "I'm just a humble example"
 ```
 
-
 ## id
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id-1)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
 
@@ -142,40 +116,26 @@ An about ids. It is meta. If you are confused, send an email to the address spec
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#metaid)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://example.com/schemas/extensible#/definitions/second`
-
+- []() – `https://example.com/schemas/extensible#/definitions/second`
 
 #### Requirement 2
 
-
-* []() – `https://example.com/schemas/definitions#/definitions/myid`
-
+- []() – `https://example.com/schemas/definitions#/definitions/myid`
 
 #### Requirement 3
 
-
-* []() – `#/definitions/third`
-
+- []() – `#/definitions/third`

--- a/examples/docs/extensible.schema.md
+++ b/examples/docs/extensible.schema.md
@@ -11,16 +11,16 @@ https://example.com/schemas/extensible
 
 This is an extensible schema. It has `definitions`, that can be used in other schemas
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [extensible.schema.json](extensible.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                       |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------ |
+| Cannot be instantiated     | Yes        | Experimental           | No           | Forbidden         | Permitted             | [extensible.schema.json](extensible.schema.json) |
 
 # Extensible Definitions
 
-| Property | Type | Group |
-|----------|------|-------|
+| Property    | Type     | Group                                                        |
+| ----------- | -------- | ------------------------------------------------------------ |
 | [bar](#bar) | `string` | `https://example.com/schemas/extensible#/definitions/second` |
-| [foo](#foo) | `string` | `https://example.com/schemas/extensible#/definitions/first` |
+| [foo](#foo) | `string` | `https://example.com/schemas/extensible#/definitions/first`  |
 
 ## bar
 
@@ -28,19 +28,13 @@ A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -52,31 +46,22 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## foo
 
 A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/examples/docs/identifiable.schema.md
+++ b/examples/docs/identifiable.schema.md
@@ -9,18 +9,18 @@ foo: bar
 https://example.com/schemas/identifiable
 ```
 
-This is a *very* simple example of a JSON schema. There is only one property.
+This is a _very_ simple example of a JSON schema. There is only one property.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | Yes | Forbidden | Permitted | [identifiable.schema.json](identifiable.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                           |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | Yes          | Forbidden         | Permitted             | [identifiable.schema.json](identifiable.schema.json) |
 
 # Identifiable Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | Identifiable (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property   | Type     | Required   | Nullable | Defined by                                 |
+| ---------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [@id](#id) | `string` | Optional   | No       | Identifiable (this schema)                 |
+| `*`        | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## @id
 
@@ -28,28 +28,18 @@ A unique identifier given to every addressable thing.
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/examples/docs/join.schema.md
+++ b/examples/docs/join.schema.md
@@ -11,25 +11,19 @@ https://example.com/schemas/join
 
 This is an example of a JSON schema with only a join type key. Here a 'oneOf'.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [join.schema.json](join.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                           |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [join.schema.json](join.schema.json) |
 
-
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `foo`    | string | Optional |
 
 #### foo
 
@@ -37,18 +31,12 @@ A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
 
 ##### foo Example
 
@@ -56,20 +44,13 @@ A simple string.
 hello
 ```
 
-
-
-
 #### Condition 2
-
 
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `bar`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `bar`    | string | Optional |
 
 #### bar
 
@@ -77,24 +58,15 @@ A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### bar Type
 
-
 `string`
-
-
-
-
-
 
 ##### bar Example
 
 ```json
 world
 ```
-
-
-

--- a/examples/docs/nestedobj.schema.md
+++ b/examples/docs/nestedobj.schema.md
@@ -9,16 +9,15 @@ foo: bar
 https://example.com/schemas/nestedobject
 ```
 
-
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [nestedobj.schema.json](nestedobj.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Forbidden             | [nestedobj.schema.json](nestedobj.schema.json) |
 
 # Nested Object Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [settings](#settings) | `object` | Optional  | No | Nested Object (this schema) |
+| Property              | Type     | Required | Nullable | Defined by                  |
+| --------------------- | -------- | -------- | -------- | --------------------------- |
+| [settings](#settings) | `object` | Optional | No       | Nested Object (this schema) |
 
 ## settings
 
@@ -26,21 +25,17 @@ settings
 
 `settings`
 
-* is optional
-* type: `object`
-* defined in this schema
+- is optional
+- type: `object`
+- defined in this schema
 
 ### settings Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `collaborators`| object | Optional |
-
-
+| Property        | Type   | Required |
+| --------------- | ------ | -------- |
+| `collaborators` | object | Optional |
 
 #### collaborators
 
@@ -48,46 +43,24 @@ collaborators
 
 `collaborators`
 
-* is optional
-* type: `object`
+- is optional
+- type: `object`
 
 ##### collaborators Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `id`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `id`     | string | Optional |
 
 #### id
 
-
 `id`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### id Type
 
-
 `string`
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/examples/docs/pattern.schema.md
+++ b/examples/docs/pattern.schema.md
@@ -11,35 +11,28 @@ https://example.com/schemas/pattern
 
 This is an example of a JSON schema with only a `patternProperties` key.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [pattern.schema.json](pattern.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [pattern.schema.json](pattern.schema.json) |
 
 ## Pattern: `[0-9]`
-Applies to all properties that match the regular expression `[0-9]`
 
+Applies to all properties that match the regular expression `[0-9]`
 
 A simple string.
 
 `[0-9]`
 
-* is a property pattern
-* type: `string`
-* defined in this schema
+- is a property pattern
+- type: `string`
+- defined in this schema
 
 ### Pattern [0-9] Type
 
-
 `string`
-
-
-
-
-
 
 ### [0-9] Example
 
 ```json
 "bar"
 ```
-

--- a/examples/docs/simple.schema.md
+++ b/examples/docs/simple.schema.md
@@ -9,18 +9,18 @@ foo: bar
 https://example.com/schemas/simple
 ```
 
-This is a *very* simple example of a JSON schema. There is only one property.
+This is a _very_ simple example of a JSON schema. There is only one property.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [simple.schema.json](simple.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [simple.schema.json](simple.schema.json) |
 
 # Simple Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Simple (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Simple (this schema)                       |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
 
@@ -28,28 +28,18 @@ A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/examples/docs/simpletypes.schema.md
+++ b/examples/docs/simpletypes.schema.md
@@ -11,32 +11,32 @@ https://example.com/schemas/simpletypes
 
 This is an example schema with examples for multiple types and their constraints.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [simpletypes.schema.json](simpletypes.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [simpletypes.schema.json](simpletypes.schema.json) |
 
 # Simple Types Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [integer_threes](#integer_threes) | `integer` | Optional  | No | Simple Types (this schema) |
-| [interger_constrained](#interger_constrained) | `integer` | Optional  | No | Simple Types (this schema) |
-| [interger_unconstrained](#interger_unconstrained) | `integer` | Optional  | No | Simple Types (this schema) |
-| [number_constrained](#number_constrained) | `number` | Optional  | No | Simple Types (this schema) |
-| [number_unconstrained](#number_unconstrained) | `number` | Optional  | No | Simple Types (this schema) |
-| [string_date](#string_date) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_email](#string_email) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_hostname](#string_hostname) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_ipv4](#string_ipv4) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_ipv6](#string_ipv6) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_length](#string_length) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern](#string_pattern) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern_noexample](#string_pattern_noexample) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern_singleexample](#string_pattern_singleexample) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_unconstrained](#string_unconstrained) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_uri](#string_uri) | `string` | Optional  | No | Simple Types (this schema) |
-| [yesno](#yesno) | `boolean` | **Required**  | No | Simple Types (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                                                      | Type      | Required     | Nullable | Defined by                                 |
+| ------------------------------------------------------------- | --------- | ------------ | -------- | ------------------------------------------ |
+| [integer_threes](#integer_threes)                             | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [interger_constrained](#interger_constrained)                 | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [interger_unconstrained](#interger_unconstrained)             | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [number_constrained](#number_constrained)                     | `number`  | Optional     | No       | Simple Types (this schema)                 |
+| [number_unconstrained](#number_unconstrained)                 | `number`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_date](#string_date)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_email](#string_email)                                 | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_hostname](#string_hostname)                           | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_ipv4](#string_ipv4)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_ipv6](#string_ipv6)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_length](#string_length)                               | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern](#string_pattern)                             | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern_noexample](#string_pattern_noexample)         | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern_singleexample](#string_pattern_singleexample) | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_unconstrained](#string_unconstrained)                 | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_uri](#string_uri)                                     | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [yesno](#yesno)                                               | `boolean` | **Required** | No       | Simple Types (this schema)                 |
+| `*`                                                           | any       | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## integer_threes
 
@@ -44,22 +44,17 @@ Guess what number is valid
 
 `integer_threes`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### integer_threes Type
 
-
 `integer`
 
-* minimum value: `2`
-* maximum value: `4`
-* must be a multiple of `3`
-
-
-
-
+- minimum value: `2`
+- maximum value: `4`
+- must be a multiple of `3`
 
 ## interger_constrained
 
@@ -67,21 +62,15 @@ Just a whole number. I don't like fractions. Don't get too small
 
 `interger_constrained`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### interger_constrained Type
 
-
 `integer`
 
-* minimum value: `10`
-
-
-
-
-
+- minimum value: `10`
 
 ## interger_unconstrained
 
@@ -89,20 +78,13 @@ Just a whole number. I don't like fractions.
 
 `interger_unconstrained`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### interger_unconstrained Type
 
-
 `integer`
-
-
-
-
-
-
 
 ## number_constrained
 
@@ -110,20 +92,15 @@ Just a number. Don't get too big.
 
 `number_constrained`
 
-* is optional
-* type: `number`
-* defined in this schema
+- is optional
+- type: `number`
+- defined in this schema
 
 ### number_constrained Type
 
-
 `number`
 
-* value must not be greater or equal than: `10`
-
-
-
-
+- value must not be greater or equal than: `10`
 
 ## number_unconstrained
 
@@ -131,20 +108,13 @@ Just a number
 
 `number_unconstrained`
 
-* is optional
-* type: `number`
-* defined in this schema
+- is optional
+- type: `number`
+- defined in this schema
 
 ### number_unconstrained Type
 
-
 `number`
-
-
-
-
-
-
 
 ## string_date
 
@@ -152,21 +122,15 @@ A date-like string.
 
 `string_date`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_date Type
 
-
 `string`
 
-* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
-
-
-
-
-
+- format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 ## string_email
 
@@ -174,21 +138,15 @@ An email-like string.
 
 `string_email`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_email Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
-
-
-
-
-
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 ## string_hostname
 
@@ -196,21 +154,15 @@ A hostname-like string.
 
 `string_hostname`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_hostname Type
 
-
 `string`
 
-* format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
-
-
-
-
-
+- format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
 
 ## string_ipv4
 
@@ -218,21 +170,15 @@ An IPv4-like string.
 
 `string_ipv4`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_ipv4 Type
 
-
 `string`
 
-* format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
-
-
-
-
-
+- format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
 
 ## string_ipv6
 
@@ -240,21 +186,15 @@ An IPv6-like string.
 
 `string_ipv6`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_ipv6 Type
 
-
 `string`
 
-* format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
-
-
-
-
-
+- format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
 
 ## string_length
 
@@ -262,19 +202,16 @@ A string with minumum and maximum length
 
 `string_length`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_length Type
 
-
 `string`
 
-* minimum length: 3 characters
-* maximum length: 3 characters
-
-
+- minimum length: 3 characters
+- maximum length: 3 characters
 
 ### string_length Examples
 
@@ -286,50 +223,44 @@ A string with minumum and maximum length
 "baz"
 ```
 
-
-
 ## string_pattern
 
 A string following a regular expression
 
 `string_pattern`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern Type
 
-
 `string`
 
+All instances must conform to this regular expression
 
-
-All instances must conform to this regular expression 
 ```regex
 ^ba.$
 ```
 
-* test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
-* test example: [baz](https://regexr.com/?expression=%5Eba.%24&text=baz)
-* test example: [bat](https://regexr.com/?expression=%5Eba.%24&text=bat)
-
+- test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
+- test example: [baz](https://regexr.com/?expression=%5Eba.%24&text=baz)
+- test example: [bat](https://regexr.com/?expression=%5Eba.%24&text=bat)
 
 ### string_pattern Known Values
-| Value | Description |
-|-------|-------------|
-| `baa` | the sounds of sheeps |
-| `bad` | German bathroom |
-| `bag` | holding device |
-| `bah` | humbug! |
-| `bam` | a loud sound |
-| `ban` | don&#39;t do this |
-| `bap` | a British soft bread roll |
+
+| Value | Description                                           |
+| ----- | ----------------------------------------------------- |
+| `baa` | the sounds of sheeps                                  |
+| `bad` | German bathroom                                       |
+| `bag` | holding device                                        |
+| `bah` | humbug!                                               |
+| `bam` | a loud sound                                          |
+| `ban` | don&#39;t do this                                     |
+| `bap` | a British soft bread roll                             |
 | `bas` | from ancient Egyptian religion, an aspect of the soul |
-| `bat` | …out of hell |
-| `bay` | , sitting by the dock of the |
-
-
+| `bat` | …out of hell                                          |
+| `bay` | , sitting by the dock of the                          |
 
 ### string_pattern Examples
 
@@ -345,35 +276,25 @@ All instances must conform to this regular expression
 "bat"
 ```
 
-
-
 ## string_pattern_noexample
 
 A string following a regular expression
 
 `string_pattern_noexample`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern_noexample Type
 
-
 `string`
 
+All instances must conform to this regular expression (test examples [here](https://regexr.com/?expression=%5Eba.%24)):
 
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5Eba.%24)):
 ```regex
 ^ba.$
 ```
-
-
-
-
-
 
 ## string_pattern_singleexample
 
@@ -381,26 +302,21 @@ A string following a regular expression
 
 `string_pattern_singleexample`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern_singleexample Type
 
-
 `string`
 
+All instances must conform to this regular expression
 
-
-All instances must conform to this regular expression 
 ```regex
 ^ba.$
 ```
 
-* test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
-
-
-
+- test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
 
 ### string_pattern_singleexample Example
 
@@ -408,26 +324,19 @@ All instances must conform to this regular expression
 "bar"
 ```
 
-
 ## string_unconstrained
 
 A simple string, without any constraints.
 
 `string_unconstrained`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_unconstrained Type
 
-
 `string`
-
-
-
-
-
 
 ### string_unconstrained Example
 
@@ -435,43 +344,30 @@ A simple string, without any constraints.
 "bar"
 ```
 
-
 ## string_uri
 
 A URI.
 
 `string_uri`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_uri Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## yesno
 
-
 `yesno`
 
-* is **required**
-* type: `boolean`
-* defined in this schema
+- is **required**
+- type: `boolean`
+- defined in this schema
 
 ### yesno Type
 
-
 `boolean`
-
-
-
-

--- a/examples/docs/stabilizing.schema.md
+++ b/examples/docs/stabilizing.schema.md
@@ -11,16 +11,16 @@ https://example.com/schemas/stabilizing
 
 This is a schema which is currently in the `stabilizing` status.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Stabilizing | No | Forbidden | Permitted | [stabilizing.schema.json](stabilizing.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | No         | Stabilizing            | No           | Forbidden         | Permitted             | [stabilizing.schema.json](stabilizing.schema.json) |
 
 # Stabilizing Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Stabilizing (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Stabilizing (this schema)                  |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
 
@@ -28,28 +28,18 @@ A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/examples/docs/subdir/subdir.schema.md
+++ b/examples/docs/subdir/subdir.schema.md
@@ -11,16 +11,16 @@ https://example.com/schemas/subdir/subdir
 
 A schema in a sub directory
 
-| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|-------------------------------|------------|---------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir.schema.json) |
+| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                      |
+| ----------------------------- | ---------- | ------------------------- | ------------ | ----------------- | --------------------- | ----------------------------------------------- |
+| Can be instantiated           | Yes        | Experimental              | No           | Forbidden         | Permitted             | [subdir/subdir.schema.json](subdir.schema.json) |
 
 # Subdir Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Subdir (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Subdir (this schema)                       |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
 
@@ -28,28 +28,18 @@ A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/content`
-
+- []() – `#/definitions/content`

--- a/examples/docs/typearrays.schema.md
+++ b/examples/docs/typearrays.schema.md
@@ -11,19 +11,19 @@ https://example.com/schemas/typearrays
 
 This schema test type arrays and nullable types
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [typearrays.schema.json](typearrays.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                       |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [typearrays.schema.json](typearrays.schema.json) |
 
 # Type Arrays Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [null](#null) | `null` | Optional  | No | Type Arrays (this schema) |
-| [string-or-null](#string-or-null) | `string` | Optional  | Yes | Type Arrays (this schema) |
-| [string-or-number](#string-or-number) | multiple | Optional  | No | Type Arrays (this schema) |
-| [string-or-number-null](#string-or-number-null) | multiple | Optional  | Yes | Type Arrays (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                                        | Type     | Required   | Nullable | Defined by                                 |
+| ----------------------------------------------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [null](#null)                                   | `null`   | Optional   | No       | Type Arrays (this schema)                  |
+| [string-or-null](#string-or-null)               | `string` | Optional   | Yes      | Type Arrays (this schema)                  |
+| [string-or-number](#string-or-number)           | multiple | Optional   | No       | Type Arrays (this schema)                  |
+| [string-or-number-null](#string-or-number-null) | multiple | Optional   | Yes      | Type Arrays (this schema)                  |
+| `*`                                             | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## null
 
@@ -31,18 +31,13 @@ This is just nothing
 
 `null`
 
-* is optional
-* type: `null`
-* defined in this schema
+- is optional
+- type: `null`
+- defined in this schema
 
 ### null Type
 
-
-`null`
-This property can only have the value `null`.
-
-
-
+`null` This property can only have the value `null`.
 
 ## string-or-null
 
@@ -50,20 +45,13 @@ Nullable string
 
 `string-or-null`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string-or-null Type
 
-
 `string`, nullable
-
-
-
-
-
-
 
 ## string-or-number
 
@@ -71,20 +59,16 @@ Types can be many things
 
 `string-or-number`
 
-* is optional
-* type: multiple
-* defined in this schema
+- is optional
+- type: multiple
+- defined in this schema
 
 ### string-or-number Type
 
-
 Either one of:
- * `string`
- * `number`
 
-
-
-
+- `string`
+- `number`
 
 ## string-or-number-null
 
@@ -92,28 +76,20 @@ Types can be many things, even nothing at all.
 
 `string-or-number-null`
 
-* is optional
-* type: multiple
-* defined in this schema
+- is optional
+- type: multiple
+- defined in this schema
 
 ### string-or-number-null Type
 
-
 Either one of:
- * `string`
- * `number`
- * or `null`
 
+- `string`
+- `number`
+- or `null`
 
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/lib/markdownWriter.js
+++ b/lib/markdownWriter.js
@@ -6,6 +6,7 @@
  */
 
 const writeFile = require('./writeFiles');
+const prettyMarkdown = require('./prettyMarkdown');
 var Promise=require('bluebird');
 var path = require('path');
 var _ = require('lodash');
@@ -292,7 +293,7 @@ const generateMarkdown = function(filename, schema, schemaPath, outDir, dependen
 
   return Promise.reduce(Promise.map(multi, render), build, '').then(str => {
     const mdfile = path.basename(filename).slice(0, -5)+ '.md';
-    return writeFile(path.join(path.join(outDir), path.dirname(filename.substr(schemaPath.length))), mdfile, str);
+    return writeFile(path.join(path.join(outDir), path.dirname(filename.substr(schemaPath.length))), mdfile, prettyMarkdown(str));
   }).then(out => {
     //console.log('markdown written (promise)', out);
     return out;

--- a/lib/prettyMarkdown.js
+++ b/lib/prettyMarkdown.js
@@ -1,0 +1,14 @@
+/**
+ * Copyright 2017 Adobe Systems Incorporated. All rights reserved.
+ * This file is licensed to you under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License. You may obtain a copy
+ * of the License at http://www.apache.org/licenses/LICENSE-2.0
+ */
+
+var prettier = require('prettier');
+
+const prettyMarkdown = function(str) {
+  return prettier.format(str, { parser: 'markdown', proseWrap: 'always', printWidth: 119 });
+};
+
+module.exports = prettyMarkdown;

--- a/lib/readmeWriter.js
+++ b/lib/readmeWriter.js
@@ -6,6 +6,7 @@
  */
 
 const writeFile = require('./writeFiles');
+const prettyMarkdown = require('./prettyMarkdown');
 var Promise=require('bluebird');
 var _ = require('lodash');
 var ejs = require('ejs');
@@ -54,7 +55,7 @@ const generateReadme = function(paths, schemas, out, base) {
 
   return pejs.renderFileAsync(path.join(__dirname, '../templates/md/readme.ejs'), ctx, { debug: false }).then(str => {
     console.log('Writing README');
-    return writeFile(out, 'README.md', str);
+    return writeFile(out, 'README.md', prettyMarkdown(str));
   }).then(out => {
     //console.log('markdown written (promise)', out);
     return out;

--- a/package-lock.json
+++ b/package-lock.json
@@ -577,9 +577,9 @@
       "dev": true
     },
     "bluebird": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.3.tgz",
-      "integrity": "sha1-fQHG+WFsmlGrD4xUmnnf5uwz76c="
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
+      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw=="
     },
     "bottleneck": {
       "version": "2.17.1",
@@ -7563,6 +7563,11 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
       "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
       "dev": true
+    },
+    "prettier": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.17.0.tgz",
+      "integrity": "sha512-sXe5lSt2WQlCbydGETgfm1YBShgOX4HxQkFPvbxkcwgDvGDeqVau8h+12+lmSVlP3rHPz0oavfddSZg/q+Szjw=="
     },
     "process-nextick-args": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.5.0",
     "mkdirp": "^0.5.1",
     "optimist": "^0.6.1",
+    "prettier": "^1.17.0",
     "readdirp": "^2.1.0",
     "valid-url": "1.0.9",
     "winston": "^3.1.0"

--- a/spec/examples/README.md
+++ b/spec/examples/README.md
@@ -1,33 +1,28 @@
-
-
- # Readme
-
-
+# Readme
 
 ## /
 
-* [Abstract](./abstract.schema.md) – `https://example.com/schemas/abstract` (Unknown)
-* [Arrays](./arrays.schema.md) – `https://example.com/schemas/arrays` (Unknown)
-* [Complex References ](./complex.schema.md) – `https://example.com/schemas/complex` (Unknown)
-* [Constant Types](./constants.schema.md) – `https://example.com/schemas/constants` (Unknown)
-* [Custom](./custom.schema.md) – `https://example.com/schemas/custom` (Unknown)
-* [Deeply Extending](./deepextending.schema.md) – `https://example.com/schemas/deepextending` (Unknown)
-* [Definitions](./definitions.schema.md) – `https://example.com/schemas/definitions` (Unknown)
-* [Enumerated ](./enums.schema.md) – `https://example.com/schemas/enums` (Unknown)
-* [Example](./example.schema.md) – `https://example.com/schemas/example` (Unknown)
-* [Examples](./examples.schema.md) – `https://example.com/schemas/examples` (Unknown)
-* [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
-* [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
-* [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
-* [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
-* [Nested Object](./nestedobj.schema.md) – `https://example.com/schemas/nestedobject` (Unknown)
-* [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
-* [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
-* [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
-* [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)
-* [Type Arrays](./typearrays.schema.md) – `https://example.com/schemas/typearrays` (Unknown)
+- [Abstract](./abstract.schema.md) – `https://example.com/schemas/abstract` (Unknown)
+- [Arrays](./arrays.schema.md) – `https://example.com/schemas/arrays` (Unknown)
+- [Complex References ](./complex.schema.md) – `https://example.com/schemas/complex` (Unknown)
+- [Constant Types](./constants.schema.md) – `https://example.com/schemas/constants` (Unknown)
+- [Custom](./custom.schema.md) – `https://example.com/schemas/custom` (Unknown)
+- [Deeply Extending](./deepextending.schema.md) – `https://example.com/schemas/deepextending` (Unknown)
+- [Definitions](./definitions.schema.md) – `https://example.com/schemas/definitions` (Unknown)
+- [Enumerated ](./enums.schema.md) – `https://example.com/schemas/enums` (Unknown)
+- [Example](./example.schema.md) – `https://example.com/schemas/example` (Unknown)
+- [Examples](./examples.schema.md) – `https://example.com/schemas/examples` (Unknown)
+- [Extending](./extending.schema.md) – `https://example.com/schemas/extending` (Unknown)
+- [Extensible](./extensible.schema.md) – `https://example.com/schemas/extensible` (Unknown)
+- [Identifiable](./identifiable.schema.md) – `https://example.com/schemas/identifiable` (Unknown)
+- [Join Types](./join.schema.md) – `https://example.com/schemas/join` (Unknown)
+- [Nested Object](./nestedobj.schema.md) – `https://example.com/schemas/nestedobject` (Unknown)
+- [Pattern Properties](./pattern.schema.md) – `https://example.com/schemas/pattern` (Unknown)
+- [Simple](./simple.schema.md) – `https://example.com/schemas/simple` (Unknown)
+- [Simple Types](./simpletypes.schema.md) – `https://example.com/schemas/simpletypes` (Unknown)
+- [Stabilizing](./stabilizing.schema.md) – `https://example.com/schemas/stabilizing` (Stabilizing)
+- [Type Arrays](./typearrays.schema.md) – `https://example.com/schemas/typearrays` (Unknown)
 
 ## /subdir/
 
-* [Subdir](./subdir/subdir.schema.md) – `https://example.com/schemas/subdir/subdir` (Unknown)
-
+- [Subdir](./subdir/subdir.schema.md) – `https://example.com/schemas/subdir/subdir` (Unknown)

--- a/spec/examples/abstract.schema.md
+++ b/spec/examples/abstract.schema.md
@@ -11,79 +11,58 @@ https://example.com/schemas/abstract
 
 This is an abstract schema. It has `definitions`, but does not declare any properties
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [abstract.schema.json](abstract.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                   |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------- |
+| Cannot be instantiated     | Yes        | Experimental           | No           | Forbidden         | Permitted             | [abstract.schema.json](abstract.schema.json) |
 
 # Abstract Definitions
 
-| Property | Type | Group |
-|----------|------|-------|
-| [bar](#bar) | `string` | `https://example.com/schemas/abstract#/definitions/second` |
-| [foo](#foo) | `string` | `https://example.com/schemas/abstract#/definitions/first` |
-| [nonfoo](#nonfoo) | `const` | `https://example.com/schemas/abstract#/definitions/first` |
+| Property          | Type     | Group                                                      |
+| ----------------- | -------- | ---------------------------------------------------------- |
+| [bar](#bar)       | `string` | `https://example.com/schemas/abstract#/definitions/second` |
+| [foo](#foo)       | `string` | `https://example.com/schemas/abstract#/definitions/first`  |
+| [nonfoo](#nonfoo) | `const`  | `https://example.com/schemas/abstract#/definitions/first`  |
 
 ## bar
-
 
 A unique identifier given to every addressable thing.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
 
-
-
-
-
-
-
 ## foo
-
 
 A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
 
-
-
-
-
-
-
 ## nonfoo
-
 
 This is not foo.
 
 `nonfoo`
 
-* is optional
-* type: `const`
-* defined in this schema
+- is optional
+- type: `const`
+- defined in this schema
 
 The value of this property **must** be equal to:
 
 ```json
 false
 ```
-
-
-
-

--- a/spec/examples/arrays.schema.md
+++ b/spec/examples/arrays.schema.md
@@ -11,77 +11,63 @@ https://example.com/schemas/arrays
 
 This is an example schema with examples for multiple array types and their constraints.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [arrays.schema.json](arrays.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [arrays.schema.json](arrays.schema.json) |
 
 # Arrays Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [JoinTypelist](#jointypelist) | `array` | Optional  | No | Arrays (this schema) |
-| [boollist](#boollist) | `boolean[]` | Optional  | No | Arrays (this schema) |
-| [coordinatelist](#coordinatelist) | `number[][]` | Optional  | No | Arrays (this schema) |
-| [intlist](#intlist) | `integer[]` | Optional  | No | Arrays (this schema) |
-| [list](#list) | `string[]` | Optional  | No | Arrays (this schema) |
-| [listlist](#listlist) | `array[]` | Optional  | No | Arrays (this schema) |
-| [numlist](#numlist) | `number[]` | Optional  | No | Arrays (this schema) |
-| [objectlist](#objectlist) | `object[]` | Optional  | No | Arrays (this schema) |
-| [stringlistlist](#stringlistlist) | `string[][]` | Optional  | No | Arrays (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                          | Type         | Required   | Nullable | Defined by                                 |
+| --------------------------------- | ------------ | ---------- | -------- | ------------------------------------------ |
+| [JoinTypelist](#jointypelist)     | `array`      | Optional   | No       | Arrays (this schema)                       |
+| [boollist](#boollist)             | `boolean[]`  | Optional   | No       | Arrays (this schema)                       |
+| [coordinatelist](#coordinatelist) | `number[][]` | Optional   | No       | Arrays (this schema)                       |
+| [intlist](#intlist)               | `integer[]`  | Optional   | No       | Arrays (this schema)                       |
+| [list](#list)                     | `string[]`   | Optional   | No       | Arrays (this schema)                       |
+| [listlist](#listlist)             | `array[]`    | Optional   | No       | Arrays (this schema)                       |
+| [numlist](#numlist)               | `number[]`   | Optional   | No       | Arrays (this schema)                       |
+| [objectlist](#objectlist)         | `object[]`   | Optional   | No       | Arrays (this schema)                       |
+| [stringlistlist](#stringlistlist) | `string[][]` | Optional   | No       | Arrays (this schema)                       |
+| `*`                               | any          | Additional | Yes      | this schema _allows_ additional properties |
 
 ## JoinTypelist
-
 
 An array of simple objects
 
 `JoinTypelist`
 
-* is optional
-* type: `array`
-* defined in this schema
+- is optional
+- type: `array`
+- defined in this schema
 
 ### JoinTypelist Type
-
 
 Array type: `array`
 
 All items must be of the type:
 
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `foo`    | string | Optional |
 
 #### foo
 
-    
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
 
 ##### foo Example
 
@@ -89,40 +75,26 @@ A simple string.
 hello
 ```
 
-
-
-
 #### Condition 2
-
 
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `bar`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `bar`    | string | Optional |
 
 #### bar
 
-    
 A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### bar Type
 
-
 `string`
-
-
-
-
-
 
 ##### bar Example
 
@@ -130,298 +102,170 @@ A simple string.
 world
 ```
 
-
-
-
-  
-
-
-
-
-
-
-
 ## boollist
-
 
 This is an array
 
 `boollist`
 
-* is optional
-* type: `boolean[]`
-* at least `1` items in the array
-* defined in this schema
+- is optional
+- type: `boolean[]`
+- at least `1` items in the array
+- defined in this schema
 
 ### boollist Type
 
-
 Array type: `boolean[]`
 
-All items must be of the type:
-`boolean`
-
-
-
-
-
-
+All items must be of the type: `boolean`
 
 ## coordinatelist
-
 
 This is an array of coordinates in three-dimensional space.
 
 `coordinatelist`
 
-* is optional
-* type: `number[][]` (nested array)
-* no more than `10` items in the array
-* defined in this schema
+- is optional
+- type: `number[][]` (nested array)
+- no more than `10` items in the array
+- defined in this schema
 
 ### coordinatelist Type
 
-
 Nested array type: `number[]`
 
+All items must be of the type: `number`
 
+- minimum value: `0`
+- maximum value: `10`
 
-All items must be of the type:
-`number`
-
-* minimum value: `0`
-* maximum value: `10`
-
-
-
-
-  
 A coordinate, specified by `x`, `y`, and `z` values
 
-
-
-
-
-
-
 ## intlist
-
 
 This is an array
 
 `intlist`
 
-* is optional
-* type: `integer[]`
-* between `1` and `10` items in the array
-* defined in this schema
+- is optional
+- type: `integer[]`
+- between `1` and `10` items in the array
+- defined in this schema
 
 ### intlist Type
 
-
 Array type: `integer[]`
 
-All items must be of the type:
-`integer`
-
-
-
-
-
-
-
-
-
+All items must be of the type: `integer`
 
 ## list
-
 
 This is an array
 
 `list`
 
-* is optional
-* type: `string[]`
-* defined in this schema
+- is optional
+- type: `string[]`
+- defined in this schema
 
 ### list Type
 
-
 Array type: `string[]`
 
-All items must be of the type:
-`string`
-
-
-
-
-
-
-
-
-
+All items must be of the type: `string`
 
 ## listlist
-
 
 This is an array of arrays
 
 `listlist`
 
-* is optional
-* type: `array[]` (nested array)
-* defined in this schema
+- is optional
+- type: `array[]` (nested array)
+- defined in this schema
 
 ### listlist Type
 
-
 Nested array type: `array`
 
-
-
-
-
-
-
-
-
-
 ## numlist
-
 
 This is an array
 
 `numlist`
 
-* is optional
-* type: `number[]`
-* no more than `10` items in the array
-* defined in this schema
+- is optional
+- type: `number[]`
+- no more than `10` items in the array
+- defined in this schema
 
 ### numlist Type
 
-
 Array type: `number[]`
 
-All items must be of the type:
-`number`
+All items must be of the type: `number`
 
-* minimum value: `10`
-
-
-
-
-
-
-
+- minimum value: `10`
 
 ## objectlist
-
 
 An array of simple objects
 
 `objectlist`
 
-* is optional
-* type: `object[]`
-* defined in this schema
+- is optional
+- type: `object[]`
+- defined in this schema
 
 ### objectlist Type
 
-
 Array type: `object[]`
 
-All items must be of the type:
-`object` with following properties:
+All items must be of the type: `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `a`| string | **Required** |
-| `b`| integer | Optional |
-
-
+| Property | Type    | Required     |
+| -------- | ------- | ------------ |
+| `a`      | string  | **Required** |
+| `b`      | integer | Optional     |
 
 #### a
 
-    
 The a property
 
 `a`
 
-* is **required**
-* type: `string`
+- is **required**
+- type: `string`
 
 ##### a Type
 
-
 `string`
-
-
-
-
-
-
-
-
 
 #### b
 
-    
 The b property
 
 `b`
 
-* is optional
-* type: `integer`
+- is optional
+- type: `integer`
 
 ##### b Type
 
-
 `integer`
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 ## stringlistlist
-
 
 This is an array of arrays of strings
 
 `stringlistlist`
 
-* is optional
-* type: `string[][]` (nested array)
-* defined in this schema
+- is optional
+- type: `string[][]` (nested array)
+- defined in this schema
 
 ### stringlistlist Type
 
-
 Nested array type: `string[]`
 
-
-
-All items must be of the type:
-`string`
-
-
-
-
-
-
-
-
-
-
-
+All items must be of the type: `string`

--- a/spec/examples/complex.schema.md
+++ b/spec/examples/complex.schema.md
@@ -3,7 +3,7 @@ template: reference
 foo: bar
 ---
 
-# Complex References  Schema
+# Complex References Schema
 
 ```
 https://example.com/schemas/complex
@@ -11,161 +11,118 @@ https://example.com/schemas/complex
 
 This is an example schema that uses types defined in other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [complex.schema.json](complex.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [complex.schema.json](complex.schema.json) |
 
 ## Schema Hierarchy
 
-* Complex References  `https://example.com/schemas/complex`
-  * [Abstract](abstract.schema.md) `https://example.com/schemas/abstract`
-  * [Simple](simple.schema.md) `https://example.com/schemas/simple`
+- Complex References `https://example.com/schemas/complex`
+  - [Abstract](abstract.schema.md) `https://example.com/schemas/abstract`
+  - [Simple](simple.schema.md) `https://example.com/schemas/simple`
 
+# Complex References Properties
 
-# Complex References  Properties
-
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [and](#and) | complex | Optional  | No | Complex References  (this schema) |
-| [or](#or) | complex | Optional  | No | Complex References  (this schema) |
-| [refabstract](#refabstract) | `object` | **Required**  | No | Complex References  (this schema) |
-| [reflist](#reflist) | Simple | Optional  | No | Complex References  (this schema) |
-| [refnamed](#refnamed) | Simple | Optional  | No | Complex References  (this schema) |
-| [xor](#xor) | complex | Optional  | No | Complex References  (this schema) |
-| `int.*` | `integer` | Pattern | No | Complex References  (this schema) |
-| `str.*` | `string` | Pattern | No | Complex References  (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                    | Type      | Required     | Nullable | Defined by                                 |
+| --------------------------- | --------- | ------------ | -------- | ------------------------------------------ |
+| [and](#and)                 | complex   | Optional     | No       | Complex References (this schema)           |
+| [or](#or)                   | complex   | Optional     | No       | Complex References (this schema)           |
+| [refabstract](#refabstract) | `object`  | **Required** | No       | Complex References (this schema)           |
+| [reflist](#reflist)         | Simple    | Optional     | No       | Complex References (this schema)           |
+| [refnamed](#refnamed)       | Simple    | Optional     | No       | Complex References (this schema)           |
+| [xor](#xor)                 | complex   | Optional     | No       | Complex References (this schema)           |
+| `int.*`                     | `integer` | Pattern      | No       | Complex References (this schema)           |
+| `str.*`                     | `string`  | Pattern      | No       | Complex References (this schema)           |
+| `*`                         | any       | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## and
-
 
 Number in a range
 
 `and`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### and Type
 
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
 `number`
 
-* maximum value: `10`
-
+- maximum value: `10`
 
 #### Requirement 2
 
-
 `number`
 
-* minimum value: `0`
-
-
-
-
-
-
+- minimum value: `0`
 
 ## or
-
 
 String or number…
 
 `or`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### or Type
 
-
-**Any** following *options* needs to be fulfilled.
-
+**Any** following _options_ needs to be fulfilled.
 
 #### Option 1
 
-
 `string`
-
-
-
 
 #### Option 2
 
-
 `number`
 
-* minimum value: `0`
-
-
-
-
-
-
+- minimum value: `0`
 
 ## refabstract
 
-
 `refabstract`
 
-* is **required**
-* type: `object`
-* defined in this schema
+- is **required**
+- type: `object`
+- defined in this schema
 
 ### refabstract Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-| `nonfoo`| boolean | Optional |
-
-
+| Property | Type    | Required |
+| -------- | ------- | -------- |
+| `foo`    | string  | Optional |
+| `nonfoo` | boolean | Optional |
 
 #### foo
 
-    
 A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
-
-
-
 
 #### nonfoo
 
-    
 This is not foo.
 
 `nonfoo`
 
-* is optional
-* type: `const`
+- is optional
+- type: `const`
 
 The value of this property **must** be equal to:
 
@@ -173,133 +130,84 @@ The value of this property **must** be equal to:
 false
 ```
 
-
-
-
-
-
-
-
-
-
 ## reflist
-
 
 `reflist`
 
-* is optional
-* type: Simple
-* defined in this schema
+- is optional
+- type: Simple
+- defined in this schema
 
 ### reflist Type
-
 
 Array type: Simple
 
 All items must be of the type:
-* [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
-
-
-
-
-
-
+- [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
 ## refnamed
 
-
 `refnamed`
 
-* is optional
-* type: Simple
-* defined in this schema
+- is optional
+- type: Simple
+- defined in this schema
 
 ### refnamed Type
 
-
-* [Simple](simple.schema.md) – `https://example.com/schemas/simple`
-
-
-
-
+- [Simple](simple.schema.md) – `https://example.com/schemas/simple`
 
 ## xor
-
 
 Exclusive choice.
 
 `xor`
 
-* is optional
-* type: complex
-* defined in this schema
+- is optional
+- type: complex
+- defined in this schema
 
 ### xor Type
 
-
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `number`
 
-* maximum value: `0`
-
+- maximum value: `0`
 
 #### Condition 2
 
-
 `number`
 
-* minimum value: `10`
-
-
-
-
-
-
+- minimum value: `10`
 
 ## Pattern: `int.*`
-Applies to all properties that match the regular expression `int.*`
 
+Applies to all properties that match the regular expression `int.*`
 
 `int.*`
 
-* is a property pattern
-* type: `integer`
-* defined in this schema
+- is a property pattern
+- type: `integer`
+- defined in this schema
 
-### Pattern int.* Type
-
+### Pattern int.\* Type
 
 `integer`
 
-
-
-
-
-
-
 ## Pattern: `str.*`
-Applies to all properties that match the regular expression `str.*`
 
+Applies to all properties that match the regular expression `str.*`
 
 `str.*`
 
-* is a property pattern
-* type: `string`
-* defined in this schema
+- is a property pattern
+- type: `string`
+- defined in this schema
 
-### Pattern str.* Type
-
+### Pattern str.\* Type
 
 `string`
-
-
-
-
-
-

--- a/spec/examples/constants.schema.md
+++ b/spec/examples/constants.schema.md
@@ -11,34 +11,29 @@ https://example.com/schemas/constants
 
 This is an example schema with examples for properties with constant values
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [constants.schema.json](constants.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [constants.schema.json](constants.schema.json) |
 
 # Constant Types Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [hello](#hello) | `const` | **Required**  | No | Constant Types (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property        | Type    | Required     | Nullable | Defined by                                 |
+| --------------- | ------- | ------------ | -------- | ------------------------------------------ |
+| [hello](#hello) | `const` | **Required** | No       | Constant Types (this schema)               |
+| `*`             | any     | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## hello
-
 
 A simple string, without strong constraints.
 
 `hello`
 
-* is **required**
-* type: `const`
-* defined in this schema
+- is **required**
+- type: `const`
+- defined in this schema
 
 The value of this property **must** be equal to:
 
 ```json
 "World"
 ```
-
-
-
-

--- a/spec/examples/custom.schema.md
+++ b/spec/examples/custom.schema.md
@@ -9,82 +9,59 @@ foo: bar
 https://example.com/schemas/custom
 ```
 
-This is an extensible schema. It has `definitions`, that can be used in other schemas. Additionally, it allows custom properties.
+This is an extensible schema. It has `definitions`, that can be used in other schemas. Additionally, it allows custom
+properties.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | No | Allowed | Permitted | [custom.schema.json](custom.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | No           | Allowed           | Permitted             | [custom.schema.json](custom.schema.json) |
 
 # Custom Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | Optional  | No | Custom (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Custom (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required   | Nullable | Defined by                                 |
+| ----------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | Optional   | No       | Custom (this schema)                       |
+| [foo](#foo) | `string` | Optional   | No       | Custom (this schema)                       |
+| `*`         | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## bar
-
 
 A unique identifier given to every addressable thing.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
 
-
-
-
-
-
-
 ## foo
-
 
 A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
 
-
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
-
+- []() – `https://ns.adobe.com/xdm/common/extensible.schema.json#/definitions/@context`
 
 #### Requirement 2
 
-
-* []() – `#/definitions/first`
-
+- []() – `#/definitions/first`
 
 #### Requirement 3
 
-
-* []() – `#/definitions/second`
-
+- []() – `#/definitions/second`

--- a/spec/examples/deepextending.schema.md
+++ b/spec/examples/deepextending.schema.md
@@ -11,73 +11,58 @@ https://example.com/schemas/deepextending
 
 This is an extending schema. It is extending another extending schema. It pulls `definitions` from other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [deepextending.schema.json](deepextending.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                             |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------------ |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [deepextending.schema.json](deepextending.schema.json) |
 
 ## Schema Hierarchy
 
-* Deeply Extending `https://example.com/schemas/deepextending`
-  * [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
-  * [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
-  * [Extending](extending.schema.md) `https://example.com/schemas/extending`
-
+- Deeply Extending `https://example.com/schemas/deepextending`
+  - [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
+  - [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
+  - [Extending](extending.schema.md) `https://example.com/schemas/extending`
 
 # Deeply Extending Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | [Definitions](definitions.schema.md#id) |
-| [bar](#bar) | `string` | Optional  | No | [Extensible](extensible.schema.md#bar) |
-| [baz](#baz) | `string` | Optional  | No | [Extending](extending.schema.md#baz) |
-| [hey](#hey) | `string` | Optional  | No | Deeply Extending (this schema) |
-| [id](#id-1) | `string` | Optional  | No | [Definitions](definitions.schema.md#id-1) |
-| [meta:id](#metaid) | `string` | Optional  | No | [Definitions](definitions.schema.md#metaid) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required   | Nullable | Defined by                                  |
+| ------------------ | -------- | ---------- | -------- | ------------------------------------------- |
+| [@id](#id)         | `string` | Optional   | No       | [Definitions](definitions.schema.md#id)     |
+| [bar](#bar)        | `string` | Optional   | No       | [Extensible](extensible.schema.md#bar)      |
+| [baz](#baz)        | `string` | Optional   | No       | [Extending](extending.schema.md#baz)        |
+| [hey](#hey)        | `string` | Optional   | No       | Deeply Extending (this schema)              |
+| [id](#id-1)        | `string` | Optional   | No       | [Definitions](definitions.schema.md#id-1)   |
+| [meta:id](#metaid) | `string` | Optional   | No       | [Definitions](definitions.schema.md#metaid) |
+| `*`                | any      | Additional | Yes      | this schema _allows_ additional properties  |
 
 ## @id
-
 
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## bar
-
 
 A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in [Extensible](extensible.schema.md#bar)
+- is optional
+- type: `string`
+- defined in [Extensible](extensible.schema.md#bar)
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -89,30 +74,21 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## baz
 
 ### BAAAZ!
-
 
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
 
-* is optional
-* type: `string`
-* defined in [Extending](extending.schema.md#baz)
+- is optional
+- type: `string`
+- defined in [Extending](extending.schema.md#baz)
 
 ### baz Type
 
-
 `string`
-
-
-
-
-
 
 ### baz Example
 
@@ -120,99 +96,66 @@ This property has a unique name to demonstrate it's uniqueness.
 "I'm just a humble example"
 ```
 
-
 ## hey
-
 
 A unique identifier given to every addressable thing.
 
 `hey`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### hey Type
 
-
 `string`
 
-
-
-
-
-
-
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id-1)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
-
 
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#metaid)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://example.com/schemas/extensible#/definitions/second`
-
+- []() – `https://example.com/schemas/extensible#/definitions/second`
 
 #### Requirement 2
 
-
-* []() – `https://example.com/schemas/definitions#/definitions/myid`
-
+- []() – `https://example.com/schemas/definitions#/definitions/myid`
 
 #### Requirement 3
 
-
-* []() – `https://example.com/schemas/extending#/definitions/third`
-
+- []() – `https://example.com/schemas/extending#/definitions/third`
 
 #### Requirement 4
 
-
-* []() – `#/definitions/fourth`
-
+- []() – `#/definitions/fourth`

--- a/spec/examples/definitions.schema.md
+++ b/spec/examples/definitions.schema.md
@@ -27,95 +27,69 @@ aks.
 
 > Everything is better with a quote.
 
-
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [definitions.schema.json](definitions.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [definitions.schema.json](definitions.schema.json) |
 
 # Definitions Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | **Required**  | No | Definitions (this schema) |
-| [id](#id-1) | `string` | **Required**  | No | Definitions (this schema) |
-| [meta:id](#metaid) | `string` | Optional  | No | Definitions (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required     | Nullable | Defined by                                 |
+| ------------------ | -------- | ------------ | -------- | ------------------------------------------ |
+| [@id](#id)         | `string` | **Required** | No       | Definitions (this schema)                  |
+| [id](#id-1)        | `string` | **Required** | No       | Definitions (this schema)                  |
+| [meta:id](#metaid) | `string` | Optional     | No       | Definitions (this schema)                  |
+| `*`                | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## @id
-
 
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
-
 
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/myid`
-
+- []() – `#/definitions/myid`

--- a/spec/examples/enums.schema.md
+++ b/spec/examples/enums.schema.md
@@ -3,7 +3,7 @@ template: reference
 foo: bar
 ---
 
-# Enumerated  Schema
+# Enumerated Schema
 
 ```
 https://example.com/schemas/enums
@@ -11,88 +11,72 @@ https://example.com/schemas/enums
 
 This is an example schema with examples for properties with enum values
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [enums.schema.json](enums.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                             |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [enums.schema.json](enums.schema.json) |
 
-# Enumerated  Properties
+# Enumerated Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [hello](#hello) | `enum` | **Required**  | No | Enumerated  (this schema) |
-| [nested](#nested) | `object` | Optional  | No | Enumerated  (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property          | Type     | Required     | Nullable | Defined by                                 |
+| ----------------- | -------- | ------------ | -------- | ------------------------------------------ |
+| [hello](#hello)   | `enum`   | **Required** | No       | Enumerated (this schema)                   |
+| [nested](#nested) | `object` | Optional     | No       | Enumerated (this schema)                   |
+| `*`               | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## hello
-
 
 A simple string. Pick a value.
 
 `hello`
 
-* is **required**
-* type: `enum`
-* defined in this schema
+- is **required**
+- type: `enum`
+- defined in this schema
 
 The value of this property **must** be equal to one of the [known values below](#hello-known-values).
 
 ### hello Known Values
-| Value | Description |
-|-------|-------------|
-| `World` |  |
-| `Welt` |  |
 
-
-
+| Value   | Description |
+| ------- | ----------- |
+| `World` |             |
+| `Welt`  |             |
 
 ## nested
 
 ### Enumerated (Nested)
 
-
 This is an example schema with examples for properties of nested objects with enum values
 
 `nested`
 
-* is optional
-* type: `object`
-* defined in this schema
+- is optional
+- type: `object`
+- defined in this schema
 
 ### nested Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `test`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `test`   | string | Optional |
 
 #### test
 
-    
 A simple string. Pick a value.
 
 `test`
 
-* is optional
-* type: `enum`
+- is optional
+- type: `enum`
 
 The value of this property **must** be equal to one of the [known values below](#nested-known-values).
 
 ##### test Known Values
-| Value | Description |
-|-------|-------------|
-| `nested` |  |
-| `object` |  |
-| `works` |  |
 
-
-
-
-
-
-
-
+| Value    | Description |
+| -------- | ----------- |
+| `nested` |             |
+| `object` |             |
+| `works`  |             |

--- a/spec/examples/example.schema.md
+++ b/spec/examples/example.schema.md
@@ -11,11 +11,12 @@ https://example.com/schemas/example
 
 This is an example schema with examples. Too many examples? There can never be too many examples!
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [example.schema.json](example.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [example.schema.json](example.schema.json) |
 
 ## Example Example
+
 ```json
 {
   "foo": "bar",
@@ -25,32 +26,25 @@ This is an example schema with examples. Too many examples? There can never be t
 
 # Example Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | Optional  | No | Example (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Example (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required   | Nullable | Defined by                                 |
+| ----------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | Optional   | No       | Example (this schema)                      |
+| [foo](#foo) | `string` | Optional   | No       | Example (this schema)                      |
+| `*`         | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## bar
-
 
 A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -62,32 +56,22 @@ A simple string.
 "baz"
 ```
 
-
-
 ## foo
-
 
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/spec/examples/examples.schema.md
+++ b/spec/examples/examples.schema.md
@@ -9,11 +9,11 @@ foo: bar
 https://example.com/schemas/examples
 ```
 
-This is an example schema with *multiple* examples. Too many examples? There can never be too many examples!
+This is an example schema with _multiple_ examples. Too many examples? There can never be too many examples!
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [examples.schema.json](examples.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                   |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [examples.schema.json](examples.schema.json) |
 
 ## Examples Examples
 
@@ -31,35 +31,27 @@ This is an example schema with *multiple* examples. Too many examples? There can
 }
 ```
 
-
 # Examples Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [bar](#bar) | `string` | **Required**  | No | Examples (this schema) |
-| [foo](#foo) | `string` | Optional  | No | Examples (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property    | Type     | Required     | Nullable | Defined by                                 |
+| ----------- | -------- | ------------ | -------- | ------------------------------------------ |
+| [bar](#bar) | `string` | **Required** | No       | Examples (this schema)                     |
+| [foo](#foo) | `string` | Optional     | No       | Examples (this schema)                     |
+| `*`         | any      | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## bar
-
 
 A simple string.
 
 `bar`
 
-* is **required**
-* type: `string`
-* defined in this schema
+- is **required**
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -71,32 +63,22 @@ A simple string.
 "baz"
 ```
 
-
-
 ## foo
-
 
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/spec/examples/extending.schema.md
+++ b/spec/examples/extending.schema.md
@@ -11,71 +11,56 @@ https://example.com/schemas/extending
 
 This is an extending schema. It pulls `definitions` from other schemas.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | Yes | Forbidden | Permitted | [extending.schema.json](extending.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | Yes        | Experimental           | Yes          | Forbidden         | Permitted             | [extending.schema.json](extending.schema.json) |
 
 ## Schema Hierarchy
 
-* Extending `https://example.com/schemas/extending`
-  * [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
-  * [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
-
+- Extending `https://example.com/schemas/extending`
+  - [Extensible](extensible.schema.md) `https://example.com/schemas/extensible`
+  - [Definitions](definitions.schema.md) `https://example.com/schemas/definitions`
 
 # Extending Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | [Definitions](definitions.schema.md#id) |
-| [bar](#bar) | `string` | Optional  | No | [Extensible](extensible.schema.md#bar) |
-| [baz](#baz) | `string` | Optional  | No | Extending (this schema) |
-| [id](#id-1) | `string` | Optional  | No | [Definitions](definitions.schema.md#id-1) |
-| [meta:id](#metaid) | `string` | Optional  | No | [Definitions](definitions.schema.md#metaid) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property           | Type     | Required   | Nullable | Defined by                                  |
+| ------------------ | -------- | ---------- | -------- | ------------------------------------------- |
+| [@id](#id)         | `string` | Optional   | No       | [Definitions](definitions.schema.md#id)     |
+| [bar](#bar)        | `string` | Optional   | No       | [Extensible](extensible.schema.md#bar)      |
+| [baz](#baz)        | `string` | Optional   | No       | Extending (this schema)                     |
+| [id](#id-1)        | `string` | Optional   | No       | [Definitions](definitions.schema.md#id-1)   |
+| [meta:id](#metaid) | `string` | Optional   | No       | [Definitions](definitions.schema.md#metaid) |
+| `*`                | any      | Additional | Yes      | this schema _allows_ additional properties  |
 
 ## @id
-
 
 An `id` with an `@` in front of it. The `@` stands for "dot com"
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id)
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## bar
-
 
 A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in [Extensible](extensible.schema.md#bar)
+- is optional
+- type: `string`
+- defined in [Extensible](extensible.schema.md#bar)
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -87,30 +72,21 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## baz
 
 ### BAAAZ!
-
 
 This property has a unique name to demonstrate it's uniqueness.
 
 `baz`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### baz Type
 
-
 `string`
-
-
-
-
-
 
 ### baz Example
 
@@ -118,71 +94,48 @@ This property has a unique name to demonstrate it's uniqueness.
 "I'm just a humble example"
 ```
 
-
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#id-1)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#id-1)
 
 ### id Type
 
-
 `string`
 
-* format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri-reference` – URI Reference (according to [RFC3986](https://tools.ietf.org/html/rfc3986))
 
 ## meta:id
-
 
 An about ids. It is meta. If you are confused, send an email to the address specified in this property value.
 
 `meta:id`
 
-* is optional
-* type: `string`
-* defined in [Definitions](definitions.schema.md#metaid)
+- is optional
+- type: `string`
+- defined in [Definitions](definitions.schema.md#metaid)
 
 ### meta:id Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `https://example.com/schemas/extensible#/definitions/second`
-
+- []() – `https://example.com/schemas/extensible#/definitions/second`
 
 #### Requirement 2
 
-
-* []() – `https://example.com/schemas/definitions#/definitions/myid`
-
+- []() – `https://example.com/schemas/definitions#/definitions/myid`
 
 #### Requirement 3
 
-
-* []() – `#/definitions/third`
-
+- []() – `#/definitions/third`

--- a/spec/examples/extensible.schema.md
+++ b/spec/examples/extensible.schema.md
@@ -11,37 +11,30 @@ https://example.com/schemas/extensible
 
 This is an extensible schema. It has `definitions`, that can be used in other schemas
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Cannot be instantiated | Yes | Experimental | No | Forbidden | Permitted | [extensible.schema.json](extensible.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                       |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------ |
+| Cannot be instantiated     | Yes        | Experimental           | No           | Forbidden         | Permitted             | [extensible.schema.json](extensible.schema.json) |
 
 # Extensible Definitions
 
-| Property | Type | Group |
-|----------|------|-------|
+| Property    | Type     | Group                                                        |
+| ----------- | -------- | ------------------------------------------------------------ |
 | [bar](#bar) | `string` | `https://example.com/schemas/extensible#/definitions/second` |
-| [foo](#foo) | `string` | `https://example.com/schemas/extensible#/definitions/first` |
+| [foo](#foo) | `string` | `https://example.com/schemas/extensible#/definitions/first`  |
 
 ## bar
-
 
 A horse walks into it.
 
 `bar`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### bar Type
 
-
 `string`
-
-
-
-
-
 
 ### bar Examples
 
@@ -53,32 +46,22 @@ A horse walks into it.
 "hoo"
 ```
 
-
-
 ## foo
-
 
 A unique identifier given to every addressable thing.
 
 `foo`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### foo Type
 
-
 `string`
-
-
-
-
-
 
 ### foo Example
 
 ```json
 "bar"
 ```
-

--- a/spec/examples/identifiable.schema.md
+++ b/spec/examples/identifiable.schema.md
@@ -9,48 +9,37 @@ foo: bar
 https://example.com/schemas/identifiable
 ```
 
-This is a *very* simple example of a JSON schema. There is only one property.
+This is a _very_ simple example of a JSON schema. There is only one property.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | Yes | Forbidden | Permitted | [identifiable.schema.json](identifiable.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                           |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | Yes          | Forbidden         | Permitted             | [identifiable.schema.json](identifiable.schema.json) |
 
 # Identifiable Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [@id](#id) | `string` | Optional  | No | Identifiable (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property   | Type     | Required   | Nullable | Defined by                                 |
+| ---------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [@id](#id) | `string` | Optional   | No       | Identifiable (this schema)                 |
+| `*`        | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## @id
-
 
 A unique identifier given to every addressable thing.
 
 `@id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### @id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/spec/examples/join.schema.md
+++ b/spec/examples/join.schema.md
@@ -11,45 +11,32 @@ https://example.com/schemas/join
 
 This is an example of a JSON schema with only a join type key. Here a 'oneOf'.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [join.schema.json](join.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                           |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [join.schema.json](join.schema.json) |
 
-
-**One** of the following *conditions* need to be fulfilled.
-
+**One** of the following _conditions_ need to be fulfilled.
 
 #### Condition 1
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `foo`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `foo`    | string | Optional |
 
 #### foo
 
-    
 A simple string.
 
 `foo`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### foo Type
 
-
 `string`
-
-
-
-
-
 
 ##### foo Example
 
@@ -57,46 +44,29 @@ A simple string.
 hello
 ```
 
-
-
-
 #### Condition 2
-
 
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `bar`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `bar`    | string | Optional |
 
 #### bar
 
-    
 A simple string.
 
 `bar`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### bar Type
 
-
 `string`
-
-
-
-
-
 
 ##### bar Example
 
 ```json
 world
 ```
-
-
-

--- a/spec/examples/nestedobj.schema.md
+++ b/spec/examples/nestedobj.schema.md
@@ -9,88 +9,58 @@ foo: bar
 https://example.com/schemas/nestedobject
 ```
 
-
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Forbidden | [nestedobj.schema.json](nestedobj.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                     |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Forbidden             | [nestedobj.schema.json](nestedobj.schema.json) |
 
 # Nested Object Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [settings](#settings) | `object` | Optional  | No | Nested Object (this schema) |
+| Property              | Type     | Required | Nullable | Defined by                  |
+| --------------------- | -------- | -------- | -------- | --------------------------- |
+| [settings](#settings) | `object` | Optional | No       | Nested Object (this schema) |
 
 ## settings
-
 
 settings
 
 `settings`
 
-* is optional
-* type: `object`
-* defined in this schema
+- is optional
+- type: `object`
+- defined in this schema
 
 ### settings Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `collaborators`| object | Optional |
-
-
+| Property        | Type   | Required |
+| --------------- | ------ | -------- |
+| `collaborators` | object | Optional |
 
 #### collaborators
 
-    
 collaborators
 
 `collaborators`
 
-* is optional
-* type: `object`
+- is optional
+- type: `object`
 
 ##### collaborators Type
 
-
 `object` with following properties:
 
-
-| Property | Type | Required |
-|----------|------|----------|
-| `id`| string | Optional |
-
-
+| Property | Type   | Required |
+| -------- | ------ | -------- |
+| `id`     | string | Optional |
 
 #### id
 
-    
-
 `id`
 
-* is optional
-* type: `string`
+- is optional
+- type: `string`
 
 ##### id Type
 
-
 `string`
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/spec/examples/pattern.schema.md
+++ b/spec/examples/pattern.schema.md
@@ -11,35 +11,28 @@ https://example.com/schemas/pattern
 
 This is an example of a JSON schema with only a `patternProperties` key.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [pattern.schema.json](pattern.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                 |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [pattern.schema.json](pattern.schema.json) |
 
 ## Pattern: `[0-9]`
-Applies to all properties that match the regular expression `[0-9]`
 
+Applies to all properties that match the regular expression `[0-9]`
 
 A simple string.
 
 `[0-9]`
 
-* is a property pattern
-* type: `string`
-* defined in this schema
+- is a property pattern
+- type: `string`
+- defined in this schema
 
 ### Pattern [0-9] Type
 
-
 `string`
-
-
-
-
-
 
 ### [0-9] Example
 
 ```json
 "bar"
 ```
-

--- a/spec/examples/simple.schema.md
+++ b/spec/examples/simple.schema.md
@@ -9,48 +9,37 @@ foo: bar
 https://example.com/schemas/simple
 ```
 
-This is a *very* simple example of a JSON schema. There is only one property.
+This is a _very_ simple example of a JSON schema. There is only one property.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [simple.schema.json](simple.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                               |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ---------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [simple.schema.json](simple.schema.json) |
 
 # Simple Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Simple (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Simple (this schema)                       |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/spec/examples/simpletypes.schema.md
+++ b/spec/examples/simpletypes.schema.md
@@ -11,281 +11,207 @@ https://example.com/schemas/simpletypes
 
 This is an example schema with examples for multiple types and their constraints.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [simpletypes.schema.json](simpletypes.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [simpletypes.schema.json](simpletypes.schema.json) |
 
 # Simple Types Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [integer_threes](#integer_threes) | `integer` | Optional  | No | Simple Types (this schema) |
-| [interger_constrained](#interger_constrained) | `integer` | Optional  | No | Simple Types (this schema) |
-| [interger_unconstrained](#interger_unconstrained) | `integer` | Optional  | No | Simple Types (this schema) |
-| [number_constrained](#number_constrained) | `number` | Optional  | No | Simple Types (this schema) |
-| [number_unconstrained](#number_unconstrained) | `number` | Optional  | No | Simple Types (this schema) |
-| [string_date](#string_date) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_email](#string_email) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_hostname](#string_hostname) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_ipv4](#string_ipv4) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_ipv6](#string_ipv6) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_length](#string_length) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern](#string_pattern) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern_noexample](#string_pattern_noexample) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_pattern_singleexample](#string_pattern_singleexample) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_unconstrained](#string_unconstrained) | `string` | Optional  | No | Simple Types (this schema) |
-| [string_uri](#string_uri) | `string` | Optional  | No | Simple Types (this schema) |
-| [yesno](#yesno) | `boolean` | **Required**  | No | Simple Types (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                                                      | Type      | Required     | Nullable | Defined by                                 |
+| ------------------------------------------------------------- | --------- | ------------ | -------- | ------------------------------------------ |
+| [integer_threes](#integer_threes)                             | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [interger_constrained](#interger_constrained)                 | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [interger_unconstrained](#interger_unconstrained)             | `integer` | Optional     | No       | Simple Types (this schema)                 |
+| [number_constrained](#number_constrained)                     | `number`  | Optional     | No       | Simple Types (this schema)                 |
+| [number_unconstrained](#number_unconstrained)                 | `number`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_date](#string_date)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_email](#string_email)                                 | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_hostname](#string_hostname)                           | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_ipv4](#string_ipv4)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_ipv6](#string_ipv6)                                   | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_length](#string_length)                               | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern](#string_pattern)                             | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern_noexample](#string_pattern_noexample)         | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_pattern_singleexample](#string_pattern_singleexample) | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_unconstrained](#string_unconstrained)                 | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [string_uri](#string_uri)                                     | `string`  | Optional     | No       | Simple Types (this schema)                 |
+| [yesno](#yesno)                                               | `boolean` | **Required** | No       | Simple Types (this schema)                 |
+| `*`                                                           | any       | Additional   | Yes      | this schema _allows_ additional properties |
 
 ## integer_threes
-
 
 Guess what number is valid
 
 `integer_threes`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### integer_threes Type
 
-
 `integer`
 
-* minimum value: `2`
-* maximum value: `4`
-* must be a multiple of `3`
-
-
-
-
+- minimum value: `2`
+- maximum value: `4`
+- must be a multiple of `3`
 
 ## interger_constrained
-
 
 Just a whole number. I don't like fractions. Don't get too small
 
 `interger_constrained`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### interger_constrained Type
 
-
 `integer`
 
-* minimum value: `10`
-
-
-
-
-
+- minimum value: `10`
 
 ## interger_unconstrained
-
 
 Just a whole number. I don't like fractions.
 
 `interger_unconstrained`
 
-* is optional
-* type: `integer`
-* defined in this schema
+- is optional
+- type: `integer`
+- defined in this schema
 
 ### interger_unconstrained Type
 
-
 `integer`
 
-
-
-
-
-
-
 ## number_constrained
-
 
 Just a number. Don't get too big.
 
 `number_constrained`
 
-* is optional
-* type: `number`
-* defined in this schema
+- is optional
+- type: `number`
+- defined in this schema
 
 ### number_constrained Type
 
-
 `number`
 
-* value must not be greater or equal than: `10`
-
-
-
-
+- value must not be greater or equal than: `10`
 
 ## number_unconstrained
-
 
 Just a number
 
 `number_unconstrained`
 
-* is optional
-* type: `number`
-* defined in this schema
+- is optional
+- type: `number`
+- defined in this schema
 
 ### number_unconstrained Type
 
-
 `number`
 
-
-
-
-
-
-
 ## string_date
-
 
 A date-like string.
 
 `string_date`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_date Type
 
-
 `string`
 
-* format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
-
-
-
-
-
+- format: `date-time` – date and time (according to [RFC 3339, section 5.6](http://tools.ietf.org/html/rfc3339))
 
 ## string_email
-
 
 An email-like string.
 
 `string_email`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_email Type
 
-
 `string`
 
-* format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
-
-
-
-
-
+- format: `email` – email address (according to [RFC 5322, section 3.4.1](https://tools.ietf.org/html/rfc5322))
 
 ## string_hostname
-
 
 A hostname-like string.
 
 `string_hostname`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_hostname Type
 
-
 `string`
 
-* format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
-
-
-
-
-
+- format: `hostname` – Domain Name (according to [RFC 1034, section 3.1](https://tools.ietf.org/html/rfc1034))
 
 ## string_ipv4
-
 
 An IPv4-like string.
 
 `string_ipv4`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_ipv4 Type
 
-
 `string`
 
-* format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
-
-
-
-
-
+- format: `ipv4` – IP (v4) address (according to [RFC 2673, section 3.2](https://tools.ietf.org/html/rfc2673))
 
 ## string_ipv6
-
 
 An IPv6-like string.
 
 `string_ipv6`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_ipv6 Type
 
-
 `string`
 
-* format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
-
-
-
-
-
+- format: `ipv6` – IP (v6) address (according to [RFC 4291, section 2.2](https://tools.ietf.org/html/rfc4291))
 
 ## string_length
-
 
 A string with minumum and maximum length
 
 `string_length`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_length Type
 
-
 `string`
 
-* minimum length: 3 characters
-* maximum length: 3 characters
-
-
+- minimum length: 3 characters
+- maximum length: 3 characters
 
 ### string_length Examples
 
@@ -297,51 +223,44 @@ A string with minumum and maximum length
 "baz"
 ```
 
-
-
 ## string_pattern
-
 
 A string following a regular expression
 
 `string_pattern`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern Type
 
-
 `string`
 
+All instances must conform to this regular expression
 
-
-All instances must conform to this regular expression 
 ```regex
 ^ba.$
 ```
 
-* test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
-* test example: [baz](https://regexr.com/?expression=%5Eba.%24&text=baz)
-* test example: [bat](https://regexr.com/?expression=%5Eba.%24&text=bat)
-
+- test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
+- test example: [baz](https://regexr.com/?expression=%5Eba.%24&text=baz)
+- test example: [bat](https://regexr.com/?expression=%5Eba.%24&text=bat)
 
 ### string_pattern Known Values
-| Value | Description |
-|-------|-------------|
-| `baa` | the sounds of sheeps |
-| `bad` | German bathroom |
-| `bag` | holding device |
-| `bah` | humbug! |
-| `bam` | a loud sound |
-| `ban` | don&#39;t do this |
-| `bap` | a British soft bread roll |
+
+| Value | Description                                           |
+| ----- | ----------------------------------------------------- |
+| `baa` | the sounds of sheeps                                  |
+| `bad` | German bathroom                                       |
+| `bag` | holding device                                        |
+| `bah` | humbug!                                               |
+| `bam` | a loud sound                                          |
+| `ban` | don&#39;t do this                                     |
+| `bap` | a British soft bread roll                             |
 | `bas` | from ancient Egyptian religion, an aspect of the soul |
-| `bat` | …out of hell |
-| `bay` | , sitting by the dock of the |
-
-
+| `bat` | …out of hell                                          |
+| `bay` | , sitting by the dock of the                          |
 
 ### string_pattern Examples
 
@@ -357,64 +276,47 @@ All instances must conform to this regular expression
 "bat"
 ```
 
-
-
 ## string_pattern_noexample
-
 
 A string following a regular expression
 
 `string_pattern_noexample`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern_noexample Type
 
-
 `string`
 
+All instances must conform to this regular expression (test examples [here](https://regexr.com/?expression=%5Eba.%24)):
 
-
-All instances must conform to this regular expression 
-(test examples [here](https://regexr.com/?expression=%5Eba.%24)):
 ```regex
 ^ba.$
 ```
 
-
-
-
-
-
 ## string_pattern_singleexample
-
 
 A string following a regular expression
 
 `string_pattern_singleexample`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_pattern_singleexample Type
 
-
 `string`
 
+All instances must conform to this regular expression
 
-
-All instances must conform to this regular expression 
 ```regex
 ^ba.$
 ```
 
-* test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
-
-
-
+- test example: [bar](https://regexr.com/?expression=%5Eba.%24&text=bar)
 
 ### string_pattern_singleexample Example
 
@@ -422,27 +324,19 @@ All instances must conform to this regular expression
 "bar"
 ```
 
-
 ## string_unconstrained
-
 
 A simple string, without any constraints.
 
 `string_unconstrained`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_unconstrained Type
 
-
 `string`
-
-
-
-
-
 
 ### string_unconstrained Example
 
@@ -450,44 +344,30 @@ A simple string, without any constraints.
 "bar"
 ```
 
-
 ## string_uri
-
 
 A URI.
 
 `string_uri`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string_uri Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
-
-
-
-
-
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
 ## yesno
 
-
 `yesno`
 
-* is **required**
-* type: `boolean`
-* defined in this schema
+- is **required**
+- type: `boolean`
+- defined in this schema
 
 ### yesno Type
 
-
 `boolean`
-
-
-
-

--- a/spec/examples/stabilizing.schema.md
+++ b/spec/examples/stabilizing.schema.md
@@ -11,46 +11,35 @@ https://example.com/schemas/stabilizing
 
 This is a schema which is currently in the `stabilizing` status.
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Stabilizing | No | Forbidden | Permitted | [stabilizing.schema.json](stabilizing.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                         |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | -------------------------------------------------- |
+| Can be instantiated        | No         | Stabilizing            | No           | Forbidden         | Permitted             | [stabilizing.schema.json](stabilizing.schema.json) |
 
 # Stabilizing Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Stabilizing (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Stabilizing (this schema)                  |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`

--- a/spec/examples/subdir/subdir.schema.md
+++ b/spec/examples/subdir/subdir.schema.md
@@ -11,46 +11,35 @@ https://example.com/schemas/subdir/subdir
 
 A schema in a sub directory
 
-| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|-------------------------------|------------|---------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | Yes | Experimental | No | Forbidden | Permitted | [subdir/subdir.schema.json](subdir.schema.json) |
+| [Abstract](../../abstract.md) | Extensible | [Status](../../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                      |
+| ----------------------------- | ---------- | ------------------------- | ------------ | ----------------- | --------------------- | ----------------------------------------------- |
+| Can be instantiated           | Yes        | Experimental              | No           | Forbidden         | Permitted             | [subdir/subdir.schema.json](subdir.schema.json) |
 
 # Subdir Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [id](#id) | `string` | Optional  | No | Subdir (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property  | Type     | Required   | Nullable | Defined by                                 |
+| --------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [id](#id) | `string` | Optional   | No       | Subdir (this schema)                       |
+| `*`       | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## id
-
 
 A unique identifier given to every addressable thing.
 
 `id`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### id Type
 
-
 `string`
 
-* format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
+- format: `uri` – Uniformous Resource Identifier (according to [RFC3986](http://tools.ietf.org/html/rfc3986))
 
-
-
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/content`
-
+- []() – `#/definitions/content`

--- a/spec/examples/typearrays.schema.md
+++ b/spec/examples/typearrays.schema.md
@@ -11,113 +11,85 @@ https://example.com/schemas/typearrays
 
 This schema test type arrays and nullable types
 
-| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In |
-|----------------------------|------------|------------------------|--------------|-------------------|-----------------------|------------|
-| Can be instantiated | No | Experimental | No | Forbidden | Permitted | [typearrays.schema.json](typearrays.schema.json) |
+| [Abstract](../abstract.md) | Extensible | [Status](../status.md) | Identifiable | Custom Properties | Additional Properties | Defined In                                       |
+| -------------------------- | ---------- | ---------------------- | ------------ | ----------------- | --------------------- | ------------------------------------------------ |
+| Can be instantiated        | No         | Experimental           | No           | Forbidden         | Permitted             | [typearrays.schema.json](typearrays.schema.json) |
 
 # Type Arrays Properties
 
-| Property | Type | Required | Nullable | Defined by |
-|----------|------|----------|----------|------------|
-| [null](#null) | `null` | Optional  | No | Type Arrays (this schema) |
-| [string-or-null](#string-or-null) | `string` | Optional  | Yes | Type Arrays (this schema) |
-| [string-or-number](#string-or-number) | multiple | Optional  | No | Type Arrays (this schema) |
-| [string-or-number-null](#string-or-number-null) | multiple | Optional  | Yes | Type Arrays (this schema) |
-| `*` | any | Additional | Yes | this schema *allows* additional properties |
+| Property                                        | Type     | Required   | Nullable | Defined by                                 |
+| ----------------------------------------------- | -------- | ---------- | -------- | ------------------------------------------ |
+| [null](#null)                                   | `null`   | Optional   | No       | Type Arrays (this schema)                  |
+| [string-or-null](#string-or-null)               | `string` | Optional   | Yes      | Type Arrays (this schema)                  |
+| [string-or-number](#string-or-number)           | multiple | Optional   | No       | Type Arrays (this schema)                  |
+| [string-or-number-null](#string-or-number-null) | multiple | Optional   | Yes      | Type Arrays (this schema)                  |
+| `*`                                             | any      | Additional | Yes      | this schema _allows_ additional properties |
 
 ## null
-
 
 This is just nothing
 
 `null`
 
-* is optional
-* type: `null`
-* defined in this schema
+- is optional
+- type: `null`
+- defined in this schema
 
 ### null Type
 
-
-`null`
-This property can only have the value `null`.
-
-
-
+`null` This property can only have the value `null`.
 
 ## string-or-null
-
 
 Nullable string
 
 `string-or-null`
 
-* is optional
-* type: `string`
-* defined in this schema
+- is optional
+- type: `string`
+- defined in this schema
 
 ### string-or-null Type
 
-
 `string`, nullable
 
-
-
-
-
-
-
 ## string-or-number
-
 
 Types can be many things
 
 `string-or-number`
 
-* is optional
-* type: multiple
-* defined in this schema
+- is optional
+- type: multiple
+- defined in this schema
 
 ### string-or-number Type
 
-
 Either one of:
- * `string`
- * `number`
 
-
-
-
+- `string`
+- `number`
 
 ## string-or-number-null
-
 
 Types can be many things, even nothing at all.
 
 `string-or-number-null`
 
-* is optional
-* type: multiple
-* defined in this schema
+- is optional
+- type: multiple
+- defined in this schema
 
 ### string-or-number-null Type
 
-
 Either one of:
- * `string`
- * `number`
- * or `null`
 
+- `string`
+- `number`
+- or `null`
 
-
-
-
-
-**All** of the following *requirements* need to be fulfilled.
-
+**All** of the following _requirements_ need to be fulfilled.
 
 #### Requirement 1
 
-
-* []() – `#/definitions/id`
-
+- []() – `#/definitions/id`


### PR DESCRIPTION
Applies prettier to generated markdown files to enforce formatting consistency, and improve the readability of generated tables within a text editor.