### PR TITLE
fix(index.js): -x flag is not working properly for the suppression case

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -66,7 +66,7 @@ async function main(args) {
     .alias('x', 'schema-out')
     .describe('x', 'output JSON Schema files including description and validated examples in the specified folder, or suppress with -')
     .default('x', nodepath.resolve(nodepath.join('.', 'out')))
-    .coerce('x', x => (x === '-' ? '' : nodepath.resolve(x)))
+    .coerce('x', x => (x === '-' ? '-' : nodepath.resolve(x)))
 
     .alias('e', 'schema-extension')
     .describe('e', 'JSON Schema file extension eg. schema.json or json')


### PR DESCRIPTION
When passing `-x -` on the command line, a schema is still created in the process' cwd.
This is because the `-x` value of `-` is coerced to an empty string.
Later on, it is tested against '-' instead of empty string.