### PR TITLE
fix(deps): pin es2015-i18n-tag version

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   },
   "dependencies": {
     "@adobe/helix-log": "^4.4.0",
-    "es2015-i18n-tag": "^1.6.1",
+    "es2015-i18n-tag": "1.6.1",
     "ferrum": "^1.4.1",
     "fs-extra": "^8.1.0",
     "github-slugger": "^1.2.1",


### PR DESCRIPTION
this is in order to avoid running into https://github.com/skolmer/es2015-i18n-tag/issues/71

fixes #207

Please mention the issue #… in the pull request.

Please remember to follow the documented [commit process](https://github.com/adobe/jsonschema2md/blob/master/Contributing.md#commit-message-format), specifcally commit using `npm run commit` which will construct the commit template required for automated semantic releases.
