### PR TITLE
fix: dont use backslash for URLs on windows

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -169,7 +169,7 @@ async function main(args) {
         const target = npath.relative(
           mddir,
           npath.resolve(schemadir, npath.relative(srcdir, origin)),
-        );
+        ).split(npath.sep).join(npath.posix.sep);
         return target;
       },
     }),


### PR DESCRIPTION
Generating markdown on Windows uses the OS path seperator, backslash, not a valid URL path seperator

fix #211
