### PR TITLE
#209 fix(lib/index.js): made -h/--header a boolean arg

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -97,6 +97,7 @@ async function main(args) {
     .describe('p', 'name of a custom property which should be also in the description of an element (may be used multiple times)')
     .default('p', [])
     .alias('h', 'header')
+    .boolean('h')
     .describe('h', 'if the value is false the header will be skipped')
     .default('h', true);
 


### PR DESCRIPTION
fix #209

Currently setting `-h false` in the CLI will not work because the `header` value is set to the string `false`. In Javascript, a the string `false` is truthy, so the header will always be added.

I checked the yargs documentation and found that you can indicated that an argument should be treated as truth with [`.boolean()`](https://yargs.js.org/docs/#api-booleankey).

Made the changes and the feature seems to be working correctly since then.