### PR TITLE
fix: moved definitions to bottom of output file

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -853,8 +853,8 @@ function build({
       ...makeconstraintssection(schema, 1),
       ...makedefault(schema, 1),
       ...makeexamples(schema, 1),
-      ...makedefinitions(schema, slugger),
       ...makeproperties(schema, slugger),
+      ...makedefinitions(schema, slugger),
     ]);
     return pv;
   });


### PR DESCRIPTION
#226 Relocate definitons

Move the definition section to the bottom of output file.
