### PR TITLE
feat(schemaproxy): add support for relative paths in $ref for referring external files

### DIFF
--- a/lib/schemaProxy.js
+++ b/lib/schemaProxy.js
@@ -11,6 +11,7 @@
  */
 const ghslugger = require('github-slugger');
 const { basename, dirname, resolve } = require('path');
+const url = require('url');
 const { formatmeta } = require('./formatInfo');
 const symbols = require('./symbols');
 const { keyword } = require('./keywords');
@@ -26,6 +27,29 @@ function loadExamples(file, num = 1) {
   } catch {
     return [];
   }
+}
+
+function resolveuri(uri, curid) {
+  // Defaults to value of $id in current document
+  // Overridden below for external references
+  let fulluri = curid;
+  if (uri) {
+    let uriparts;
+    try {
+      uriparts = new url.URL(uri);
+    } catch {
+      uriparts = new url.URL(uri, 'file:');
+    }
+
+    if (uriparts.host) {
+      // Absolute URI, use directly
+      fulluri = uri;
+    } else if (uriparts.pathname && uriparts.protocol === 'file:') {
+      // Relative file path: create URI based on $id of current doc
+      fulluri = new URL(uri, curid).href;
+    }
+  }
+  return fulluri;
 }
 
 const handler = ({
@@ -112,7 +136,7 @@ const handler = ({
         if (retval[keyword`$ref`]) {
           const [uri, pointer] = retval.$ref.split('#');
           // console.log('resolving ref', uri, pointer, 'from', receiver[symbols.filename]);
-          const basedoc = uri || receiver[symbols.id];
+          const basedoc = resolveuri(uri, receiver[symbols.id]);
           if (schemas.known[basedoc]) {
             const referenced = schemas.known[basedoc][symbols.resolve](pointer);
             // inject the referenced schema into the current schema

--- a/test/schemaProxy.test.js
+++ b/test/schemaProxy.test.js
@@ -65,9 +65,21 @@ const example = {
 const referencing = {
   $schema: 'http://json-schema.org/draft-06/schema#',
   $id: 'https://example.com/schemas/referencing',
-  title: 'Referencing',
+  title: 'Referencing absolute path',
   properties: {
     $ref: 'https://example.com/schemas/example#/properties',
+    zap: {
+      type: 'boolean',
+    },
+  },
+};
+
+const referencingrel = {
+  $schema: 'http://json-schema.org/draft-06/schema#',
+  $id: 'https://example.com/schemas/referencing/relative',
+  title: 'Referencing relative path',
+  properties: {
+    $ref: '../example#/properties',
     zap: {
       type: 'boolean',
     },
@@ -141,10 +153,21 @@ describe('Testing Schema Proxy', () => {
     assert.deepStrictEqual(proxied1.properties.foo, proxied1.properties[resolve]('/foo'));
   });
 
-  it('Schema proxy resolves Reference Pointers', () => {
+  it('Schema proxy resolves absolute URIs with Reference Pointers', () => {
     const myloader = loader();
     myloader(example, 'example.schema.json');
     const proxied2 = myloader(referencing, 'referencing.schema.json');
+
+    assert.deepStrictEqual(new Set(Object.keys(proxied2.properties)), new Set([
+      '$ref', 'zap', // the two properties from the original declaration
+      'foo', 'bar', 'zip', 'zup', 'baz', // plus all the referenced properties
+    ]));
+  });
+
+  it('Schema proxy resolves relative paths with Reference Pointers', () => {
+    const myloader = loader();
+    myloader(example, 'example.schema.json');
+    const proxied2 = myloader(referencingrel, 'referencingrel.schema.json');
 
     assert.deepStrictEqual(new Set(Object.keys(proxied2.properties)), new Set([
       '$ref', 'zap', // the two properties from the original declaration


### PR DESCRIPTION
Added support for relative paths in $ref for referring external files. Relative path references are
merged with $id values in the referring doc. The merged absolute URL is used, as normal, to match $id in external docs.

Fixes https://github.com/adobe/jsonschema2md/issues/179