### PR TITLE
fix(markdownbuilder): fix string-casting of additional properties for complex values

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -469,7 +469,7 @@ function build({
 
     const additionalfacts = includeproperties.map((propname) => {
       if (definition[propname]) {
-        return listItem(text(`${propname}: ${String(definition[propname])}`));
+        return listItem(text(`${propname}: ${JSON.stringify(definition[propname])}`));
       }
       return undefined;
     }).filter(item => item !== undefined);

--- a/test/fixtures/enums/enums.schema.json
+++ b/test/fixtures/enums/enums.schema.json
@@ -20,7 +20,7 @@
       }
     },
     "withoutmeta": {
-      "bar": "foo",
+      "bar": ["blue", "oyster"],
       "enum": [
         "baa", "bad", "bag", "bah", "bam", "ban", "bap", "bas", "bat", "bay"
       ]

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -165,8 +165,8 @@ describe('Testing Markdown Builder: enums', () => {
     assertMarkdown(results.enums)
       .contains('| `"bas"` | from ancient Egyptian religion, an aspect of the soul |')
       .contains('| `"baa"` |             |')
-      .contains('foo: bar')
-      .contains('bar: foo')
+      .contains('foo: "bar"')
+      .contains('bar: \\["blue","oyster"]')
       .contains('**enum**: the value of this property must be equal to one of the following values:');
   });
 


### PR DESCRIPTION
String()-casting fails for complex JSON values of additional properties (provided by "-p" option). Switched to JSON.stringify(), which should support all cases. Might be relevant to switch also other places in the code where values may be complex.

BREAKING CHANGE: Printing of additional properties have changed slightly, e.g. from 'foo: bar' to 'foo: "bar"', which may break tests etc. for other packages that depend on jsonschema2md. Internal tests have been updated and do not break.
