### PR TITLE
Revert "fix: definition object defintions based on proplist structure"

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -779,29 +779,31 @@ function build({
    * Generates the definitions section for a schema
    * @param {*} schema
    */
-  function makedefinitions(schema) {
+  function makedefinitions(schema, slugger) {
     if (schema.definitions || schema[keyword`$defs`]) {
       const defgroups = [
         ...Object.entries(schema[keyword`$defs`] || {}),
         ...Object.entries(schema.definitions || {})]
         .map(([groupname, subschema]) => {
-          const description = subschema[s.meta] && subschema[s.meta].longdescription ? subschema[s.meta].longdescription : paragraph(text(i18n`no description`));
-
+          const grouptable = makeproptable(
+            subschema[keyword`properties`],
+            subschema[keyword`patternProperties`],
+            subschema[keyword`additionalProperties`],
+            subschema[keyword`required`],
+            slugger,
+          );
           return [
             heading(2, text(i18n`Definitions group ${groupname}`)),
             paragraph(text(i18n`Reference this group by using`)),
             code('json', JSON.stringify({ $ref: `${subschema[s.id]}#${subschema[s.pointer]}` })),
-            ...[
-              description,
-              ...makecomment(subschema),
-              paragraph(inlineCode(groupname)),
-              makefactlist(groupname, subschema),
-              ...maketypesection(subschema, 2),
-              ...makeconstraintssection(subschema, 2),
-              ...makedefault(subschema, 2),
-              ...makeexamples(subschema, 2),
-              ...makerestrictions(subschema, 2),
-            ],
+            grouptable,
+            ...makeproplist(
+              subschema[keyword`properties`],
+              subschema[keyword`patternProperties`],
+              subschema[keyword`additionalProperties`],
+              subschema[keyword`required`],
+              2,
+            ),
           ];
         });
 
@@ -852,7 +854,7 @@ function build({
       ...makedefault(schema, 1),
       ...makeexamples(schema, 1),
       ...makeproperties(schema, slugger),
-      ...makedefinitions(schema),
+      ...makedefinitions(schema, slugger),
     ]);
     return pv;
   });


### PR DESCRIPTION
This reverts commit 2fb9fc5846b64df7cd54f39e3ef10f2da5cef75e.

See #240 

@alainlecluse this reverts #229, which broke some tests. Not sure why CI didn't mark the build as failing, but this should not have happened.