### PR TITLE
fix(markdown): correcly show type of nullable types in header

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -282,7 +282,7 @@ function build({
   }
 
   function type(property) {
-    if (typeof property[keyword`type`] === 'object') {
+    if (!Array.isArray(property[keyword`type`]) && typeof property[keyword`type`] === 'object') {
       return text(i18n`Unknown Type`);
     }
     const types = Array.isArray(property[keyword`type`]) ? property[keyword`type`] : [property[keyword`type`]];

--- a/test/fixtures/nullable/array.schema.json
+++ b/test/fixtures/nullable/array.schema.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "$id": "http://example.com/type-array-repro.json",
+  "type": "object",
+  "title": "Type Array Repro",
+  "description": "Type Array Issue Reproduction",
+  "required": [
+      "sampleProp"
+  ],
+  "additionalProperties": false,
+  "properties": {
+      "sampleProp": {
+          "type": ["string", "null"],
+          "title": "Sample Property"
+      }
+  }
+}

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -62,6 +62,21 @@ not
   });
 });
 
+describe('Testing Markdown Builder: nullable', () => {
+  let results;
+
+  before(async () => {
+    const schemas = await loadschemas('nullable');
+    const builder = build({ header: false });
+    results = builder(schemas);
+  });
+
+  it('Nullable Array Type Schema looks OK', () => {
+    assertMarkdown(results.array)
+      .fuzzy`| [sampleProp](#sampleProp) | \`string\` | Required | can be null |`;
+  });
+});
+
 describe('Testing Markdown Builder: title', () => {
   let results;
 


### PR DESCRIPTION
fixes #237

Please mention the issue #… in the pull request.

Please remember to follow the documented [commit process](https://github.com/adobe/jsonschema2md/blob/master/Contributing.md#commit-message-format), specifcally commit using `npm run commit` which will construct the commit template required for automated semantic releases.
