### PR TITLE
Fixes #255: Property table anchor link, generated with github-slugger

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -309,9 +309,9 @@ function build({
    * Generates the overview table row for a single property definition
    * @param {*} param0
    */
-  function makepropheader(required = [], ispattern = false) {
+  function makepropheader(required = [], ispattern = false, slugger) {
     return ([name, definition]) => tableRow([
-      tableCell(ispattern ? inlineCode(name) : link(`#${name}`, '', text(name))), // Property
+      tableCell(ispattern ? inlineCode(name) : link(`#${slugger.slug(name)}`, '', text(name))), // Property
       tableCell(type(definition)),
       tableCell(text(required.indexOf(name) > -1 ? i18n`Required` : i18n`Optional`)),
       tableCell(nullable(definition)),


### PR DESCRIPTION
This PR fixes #255 

Modified the file markdownBuilder.js.
In the function makepropheader, the anchor link is now transformed by github-slugger.