### PR TITLE
fix(traverseschema.js): skip generating files for certain keywords in…

### DIFF
--- a/lib/traverseSchema.js
+++ b/lib/traverseSchema.js
@@ -10,8 +10,21 @@
  * governing permissions and limitations under the License.
  */
 
-const { list } = require('ferrum');
+const { list, eq } = require('ferrum');
 const { parent } = require('./symbols');
+
+function isSkippable(schema, keyword) {
+  if (typeof schema[parent] !== 'object') {
+    return false;
+  }
+  if (!Object.keys(schema[parent]).includes(keyword)) {
+    return false;
+  }
+  const skippableSchema = JSON.parse(JSON.stringify(schema[parent][keyword]));
+  const currentSchema = JSON.parse(JSON.stringify(schema));
+
+  return eq(skippableSchema, currentSchema);
+}
 
 function reducer({ seen, ids }, schema) {
   if (schema
@@ -19,15 +32,23 @@ function reducer({ seen, ids }, schema) {
     && (seen.has(schema) || (schema.$id && ids.indexOf(schema.$id) >= 0))) {
     return { seen, ids };
   } else if (Array.isArray(schema)) {
+    if (isSkippable(schema, 'examples')) {
+      return { seen, ids };
+    }
+    if (isSkippable(schema, 'required')) {
+      return { seen, ids };
+    }
     return schema.reduce(reducer, { seen, ids });
   } else if (schema && typeof schema === 'object') {
+    if (isSkippable(schema, 'properties')) {
+      return [...Object.values(schema)].reduce(reducer, { seen, ids });
+    }
     seen.add(schema);
     if (schema.$id) {
       ids.push(schema.$id);
     }
     return [...Object.values(schema)].reduce(reducer, { seen, ids });
   }
-
   return { seen, ids };
 }
 

--- a/lib/traverseSchema.js
+++ b/lib/traverseSchema.js
@@ -10,20 +10,14 @@
  * governing permissions and limitations under the License.
  */
 
-const { list, eq } = require('ferrum');
-const { parent } = require('./symbols');
+const { list, eq, contains } = require('ferrum');
+const { parent, pointer } = require('./symbols');
 
-function isSkippable(schema, keyword) {
-  if (typeof schema[parent] !== 'object') {
-    return false;
-  }
-  if (!Object.keys(schema[parent]).includes(keyword)) {
-    return false;
-  }
-  const skippableSchema = JSON.parse(JSON.stringify(schema[parent][keyword]));
-  const currentSchema = JSON.parse(JSON.stringify(schema));
+const skippableKeywords = ['examples', 'required', 'properties'];
 
-  return eq(skippableSchema, currentSchema);
+function isSkippableKeyword(schema) {
+  const containsCurrentSchema = contains(keyword => eq(keyword, schema[pointer].split('/').pop()));
+  return containsCurrentSchema(skippableKeywords);
 }
 
 function reducer({ seen, ids }, schema) {
@@ -32,15 +26,12 @@ function reducer({ seen, ids }, schema) {
     && (seen.has(schema) || (schema.$id && ids.indexOf(schema.$id) >= 0))) {
     return { seen, ids };
   } else if (Array.isArray(schema)) {
-    if (isSkippable(schema, 'examples')) {
-      return { seen, ids };
-    }
-    if (isSkippable(schema, 'required')) {
+    if (isSkippableKeyword(schema)) {
       return { seen, ids };
     }
     return schema.reduce(reducer, { seen, ids });
   } else if (schema && typeof schema === 'object') {
-    if (isSkippable(schema, 'properties')) {
+    if (isSkippableKeyword(schema)) {
       return [...Object.values(schema)].reduce(reducer, { seen, ids });
     }
     seen.add(schema);

--- a/lib/traverseSchema.js
+++ b/lib/traverseSchema.js
@@ -13,10 +13,11 @@
 const { list, eq, contains } = require('ferrum');
 const { parent, pointer } = require('./symbols');
 
-const skippableKeywords = ['examples', 'required', 'properties'];
 
 function isSkippableKeyword(schema) {
+  const skippableKeywords = ['examples', 'required', 'properties'];
   const containsCurrentSchema = contains(keyword => eq(keyword, schema[pointer].split('/').pop()));
+
   return containsCurrentSchema(skippableKeywords);
 }
 

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -73,7 +73,7 @@ describe('Testing Markdown Builder: nullable', () => {
 
   it('Nullable Array Type Schema looks OK', () => {
     assertMarkdown(results.array)
-      .fuzzy`| [sampleProp](#sampleProp) | \`string\` | Required | can be null |`;
+      .fuzzy`| [sampleProp](#sampleprop) | \`string\` | Required | can be null | [Type Array Repro](array-properties-sample-property.md "http&#x3A;//example.com/type-array-repro.json#/properties/sampleProp") |`;
   });
 });
 
@@ -92,8 +92,8 @@ describe('Testing Markdown Builder: title', () => {
   });
 
   it('Title Schema looks OK', () => {
-    assertMarkdown(results['meta-definitions-meta-properties'])
-      .fuzzy`properties Type`;
+    assertMarkdown(results['meta-definitions-meta-properties-title'])
+      .fuzzy`## title Type\n\n\`string\`\n`;
   });
 });
 

--- a/test/traverseSchema.test.js
+++ b/test/traverseSchema.test.js
@@ -70,8 +70,8 @@ describe('Testing Schema Traversal', () => {
     const proxied = loader()(example, 'example.schema.json');
     const schemas = traverse([proxied]);
 
-    assert.equal(schemas.length, 9);
-    assert.equal(schemas[8][filename], 'example.schema.json');
+    assert.equal(schemas.length, 8);
+    assert.equal(schemas[7][filename], 'example.schema.json');
   });
 
   it('Cyclic Schema Traversal generates a list', async () => {
@@ -88,7 +88,7 @@ describe('Testing Schema Traversal', () => {
     const schemas = traverse([proxiedone, proxiedtwo, proxiedthree]);
 
     assert.equal(schemas[0].$id, 'http://example.com/schemas/one');
-    assert.equal(schemas[4].$id, 'http://example.com/schemas/three');
-    assert.equal(schemas[8].$id, 'http://example.com/schemas/two');
+    assert.equal(schemas[3].$id, 'http://example.com/schemas/three');
+    assert.equal(schemas[6].$id, 'http://example.com/schemas/two');
   });
 });


### PR DESCRIPTION
… the schema

When traversing the schemas, some objects and arrays are misinterpreted as schemas to be documented
rather than as generic structures used to define the schemas. Namely: 'examples', 'required', and
'properties'. Including these structures in the loadedschemas list generates a number of extranious
files with little value to the generated documentation.

BREAKING CHANGE: The extranious files, if they have some other value, will not be generated and
there is no mechanism to continue to g

Please mention the issue #… in the pull request.

Please remember to follow the documented [commit process](https://github.com/adobe/jsonschema2md/blob/master/Contributing.md#commit-message-format), specifcally commit using `npm run commit` which will construct the commit template required for automated semantic releases.
