### PR TITLE
fix(lib/markdownBuilder.js): use simpletitle for makeproperties

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -831,7 +831,7 @@ function build({
   function makeproperties(schema, slugger) {
     if (schema[keyword`properties`] || schema[keyword`patternProperties`] || schema[keyword`additionalProperties`]) {
       return [
-        heading(1, text(i18n`${schema.title} Properties`)),
+        heading(1, text(i18n`${simpletitle(schema)} Properties`)),
         makeproptable(
           schema[keyword`properties`],
           schema[keyword`patternProperties`],


### PR DESCRIPTION
If we don't provide a title for an object, the title of the Properties list will become "undefined
Properties". By using simpletitle we avoid this and be consistent with other titles.
