### PR TITLE
fix(lib/traverseschema.js) #282 - valid 'properties' property is not rendered

### DIFF
--- a/lib/traverseSchema.js
+++ b/lib/traverseSchema.js
@@ -16,8 +16,9 @@ const { parent, pointer } = require('./symbols');
 function isSkippableKeyword(schema) {
   const skippableKeywords = ['examples', 'required', 'properties'];
   const containsCurrentSchema = contains((keyword) => eq(keyword, schema[pointer].split('/').pop()));
+  const schemaMember = schema[parent] && (schema[parent].type === 'object' || schema[parent].type === 'array');
 
-  return containsCurrentSchema(skippableKeywords);
+  return schemaMember && containsCurrentSchema(skippableKeywords);
 }
 
 function reducer({ seen, ids }, schema) {

--- a/test/traverseSchema.test.js
+++ b/test/traverseSchema.test.js
@@ -62,6 +62,24 @@ const example = {
         { $ref: '#/properties/bar' },
       ],
     },
+    properties: {
+      type: 'object',
+      description: 'properties witin properties',
+    },
+    required: {
+      type: 'array',
+      examples: [
+        [
+          {
+            properies: [],
+          },
+        ],
+      ],
+    },
+    examples: {
+      type: 'number',
+      examples: [1, 2, 3],
+    },
   },
 };
 
@@ -70,7 +88,7 @@ describe('Testing Schema Traversal', () => {
     const proxied = loader()(example, 'example.schema.json');
     const schemas = traverse([proxied]);
 
-    assert.equal(schemas.length, 8);
+    assert.equal(schemas.length, 11);
     assert.equal(schemas[7][filename], 'example.schema.json');
   });
 


### PR DESCRIPTION
`properties`, `required` and `examples` should be skipped only when they are part of the 'object' or
'array' schema type. These should not be omitted when then are part of 'properties' object, for
instance.

Now, `isSkippableKeyword` checks also the parent's type of property - it should skip the property only if it's `object` or `array` type - otherwise there is no reason to skip it at all. This change has been originally introduces within [this change](https://github.com/adobe/jsonschema2md/commit/fc50969426fd2ed0b55752f6c58d9246a22e309c) however it got "refactored" in the next commit so it wasn't effectively considered.

I consider it more as a bug, especially it has been reported as a one in #282. 

BREAKING CHANGE: If schema contained 'properties', 'required' or 'examples' as a part of JSON schema
(i.e. it was described as 'properties' within an object of 'object' type), these will be included
into output.

