### PR TITLE
fix(readmebuilder): reference twice for objects

### DIFF
--- a/lib/readmeBuilder.js
+++ b/lib/readmeBuilder.js
@@ -58,8 +58,16 @@ function build({ readme = true }) {
 
       const bytype = (type) => flist(pipe(
         schemas,
-        filter((schema) => schema[keyword`type`] === type), // remove schemas without matching type
-        filter((schema) => !!schema[s.parent]), // keep only schemas with a parent
+        filter((schema) => {
+          if (
+            schema[keyword`type`] === type // remove schemas without matching type
+            && !!schema[s.parent] // keep only schemas with a parent
+            && !schema.$ref // it is not a reference
+          ) {
+            return true;
+          }
+          return false;
+        }),
         mapSort((schema) => gentitle(schema[s.titles], schema[keyword`type`])),
         map((schema) => listItem(paragraph([
           link(`./${schema[s.slug]}.md`, gendescription(schema), [text(gentitle(schema[s.titles], schema[keyword`type`]))]),

--- a/test/fixtures/readme-1/complex.schema.json
+++ b/test/fixtures/readme-1/complex.schema.json
@@ -11,6 +11,14 @@
   "type": "object",
   "readOnly": true,
   "description": "This is an example schema that uses types defined in other schemas.",
+  "definitions": {
+    "definitionnamed": {
+      "title": "definitionnamed",
+      "type": "object",
+      "additionalProperties": true,
+      "properties": {}
+    }
+  },
   "properties": {
     "refabstract": {
       "$ref": "https://example.com/schemas/abstract#/definitions/first",
@@ -26,6 +34,9 @@
       "$ref": "#/properties/refnamed",
       "version": "1.0.0",
       "testProperty": "test"
+    },
+    "refdefinition": {
+      "$ref": "#/definitions/definitionnamed"
     },
     "refobj": {
       "type": "object",

--- a/test/readmeBuilder.test.js
+++ b/test/readmeBuilder.test.js
@@ -45,6 +45,7 @@ describe('Testing Readme Builder', () => {
     assertMarkdown(result)
       .contains('# README')
       .contains('The schemas linked above')
+      .doesNotContain('complex-properties-definitionnamed.md')
       .fuzzy`
 ## Top-level Schemas
 


### PR DESCRIPTION
This fixes #342 by filtering out schema objects that have `$ref` when building the README file.
