### PR TITLE
#252 Fix error on inputs with circular references

### DIFF
--- a/lib/schemaProxy.js
+++ b/lib/schemaProxy.js
@@ -34,7 +34,7 @@ function loadExamples(file, num = 1) {
 }
 
 const handler = ({
-  root = '', fullpath = null, filename = '.', schemas, parent = null, slugger,
+  root = '', fullpath = null, filename = '.', schemas, subschemas, parent = null, slugger,
 }) => {
   const meta = {};
 
@@ -162,14 +162,23 @@ const handler = ({
         }
 
         // console.log('making new proxy from', target, prop, 'receiver', receiver[symbols.id]);
-        const subschema = new Proxy(retval, handler({
-          root: `${root}/${prop}`,
-          parent: receiver,
-          fullpath,
-          filename,
-          schemas,
-          slugger,
-        }));
+        let subschema;
+        if (subschemas.has(retval)) {
+          subschema = subschemas.get(retval);
+        }
+        else {
+          subschema = new Proxy(retval, handler({
+            root: `${root}/${prop}`,
+            parent: receiver,
+            fullpath,
+            filename,
+            schemas,
+            subschemas,
+            slugger,
+          }));
+
+          subschemas.set(retval, subschema);
+        }
 
         if (subschema[keyword`$id`]) {
           // stow away the schema for lookup
@@ -190,6 +199,8 @@ export default function loader() {
     files: {},
   };
 
+  const subschemas = new Map();
+
   const slugger = new GhSlugger();
 
   return (/** @type {string} */ name, /** @type {any} */ schema) => {
@@ -197,7 +208,7 @@ export default function loader() {
     const filename = path.basename(name);
     const fullpath = name === filename ? undefined : name;
     const proxied = new Proxy(schema, handler({
-      filename, fullpath, schemas, slugger,
+      filename, fullpath, schemas, subschemas, slugger,
     }));
     schemas.loaded.push(proxied);
     if (proxied[keyword`$id`]) {


### PR DESCRIPTION
Fixes `UnhandledPromiseRejectionWarning: RangeError: Maximum call stack size exceeded` on inputs.

Solution proposed by @bmaranville in
https://github.com/adobe/jsonschema2md/issues/252#issuecomment-806067867. Updated to work with
7.1.1.

Fixes https://github.com/adobe/jsonschema2md/issues/252