### PR TITLE
Prevent enum crash

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -278,9 +278,9 @@ export default function build({
               (prop) => {
                 // this is a linked property
                 if (schema[s.meta]
-                    && typeof schema[s.meta][prop.name] === 'object'
-                    && schema[s.meta][prop.name].link
-                    && schema[s.meta][prop.name].text) {
+                  && typeof schema[s.meta][prop.name] === 'object'
+                  && schema[s.meta][prop.name].link
+                  && schema[s.meta][prop.name].text) {
                   return tableCell(link(rewritelinks(schema[s.meta][prop.name].link), i18n`open original schema`, [text(schema[s.meta][prop.name].text)]));
                 }
                 const value = schema[s.meta] ? schema[s.meta][prop.name] : undefined;
@@ -398,11 +398,11 @@ export default function build({
             return [listItem(paragraph(text(i18n`and all following items may follow any schema`)))];
           } else if (typeof additional === 'object') {
             return [listItem(paragraph([text(i18n`and all following items must follow the schema: `),
-              link(
-                `${additional[s.slug]}.md`,
-                i18n`check type definition`,
-                text(gentitle(additional[s.titles], additional[keyword`type`])),
-              )]))];
+            link(
+              `${additional[s.slug]}.md`,
+              i18n`check type definition`,
+              text(gentitle(additional[s.titles], additional[keyword`type`])),
+            )]))];
           }
           return [];
         })(),
@@ -579,10 +579,10 @@ export default function build({
           tableCell(text(i18n`Value`)),
           tableCell(text(i18n`Explanation`)),
         ]),
-        ...schema[keyword`enum`].map((value) => tableRow([
+        ...(Array.isArray(schema[keyword`enum`]) ? schema[keyword`enum`].map((value) => tableRow([
           tableCell(inlineCode(JSON.stringify(value))),
           tableCell(text(metas[Array.isArray(value) ? JSON.stringify(value) : value] || '')),
-        ])),
+        ])) : []),
       ]));
     }
 
@@ -664,12 +664,12 @@ export default function build({
     if (schema[keyword`minContains`] !== undefined && schema[keyword`contains`]) {
       // console.log('minContains!', schema[s.filename], schema[s.pointer]);
       constraints.push(paragraph([strong(text(i18n`minimum number of contained items`)), text(': '), text(`${i18n`this array may not contain fewer than ${String(schema[keyword`minContains`])} items that validate against the schema:`} `),
-        link(`${schema[keyword`contains`][s.slug]}.md`, i18n`check type definition`, text(gentitle(schema[keyword`contains`][s.titles], schema[keyword`contains`][keyword`type`])))]));
+      link(`${schema[keyword`contains`][s.slug]}.md`, i18n`check type definition`, text(gentitle(schema[keyword`contains`][s.titles], schema[keyword`contains`][keyword`type`])))]));
     }
     if (schema[keyword`maxContains`] !== undefined && schema[keyword`contains`]) {
       // console.log('maxContains!', schema[s.filename], schema[s.pointer]);
       constraints.push(paragraph([strong(text(i18n`maximum number of contained items`)), text(': '), text(`${i18n`this array may not contain more than ${String(schema[keyword`maxContains`])} items that validate against the schema:`} `),
-        link(`${schema[keyword`contains`][s.slug]}.md`, i18n`check type definition`, text(gentitle(schema[keyword`contains`][s.titles], schema[keyword`contains`][keyword`type`])))]));
+      link(`${schema[keyword`contains`][s.slug]}.md`, i18n`check type definition`, text(gentitle(schema[keyword`contains`][s.titles], schema[keyword`contains`][keyword`type`])))]));
     }
 
     // https://json-schema.org/draft/2019-09/json-schema-validation.html#rfc.section.6.5

--- a/test/fixtures/enums/enum-meta-enum.schema.json
+++ b/test/fixtures/enums/enum-meta-enum.schema.json
@@ -1,0 +1,74 @@
+{
+  "type": "object",
+  "properties": {
+    "homie": {
+      "type": "string",
+      "enum": [
+        "integer",
+        "float",
+        "boolean",
+        "string",
+        "enum",
+        "color",
+        "datetime",
+        "duration",
+        "json"
+      ],
+      "title": "HomieDatatype",
+      "description": "Specifies the datatype of the property value payload.",
+      "meta:enum": {
+        "integer": "TODO: describe",
+        "float": "TODO: describe",
+        "boolean": "TODO: describe.",
+        "string": "TODO: describe",
+        "enum": "TODO: describe",
+        "color": "TODO: describe",
+        "datetime": "TODO: describe",
+        "duration": "TODO: describe",
+        "json": "TODO: describe"
+      }
+    },
+    "withmeta": {
+      "foo": "bar",
+      "enum": [
+        "baa",
+        "bad",
+        "bag",
+        "bah",
+        "bam",
+        "ban",
+        "bap",
+        "bas",
+        "bat",
+        "bay"
+      ],
+      "meta:enum": {
+        "baa": "the sounds of sheeps",
+        "bad": "German bathroom",
+        "bag": "holding device",
+        "bah": "humbug!",
+        "bam": "a loud sound",
+        "ban": "don't do this",
+        "bap": "a British soft bread roll",
+        "bas": "from ancient Egyptian religion, an aspect of the soul",
+        "bat": "…out of hell",
+        "bay": ", sitting by the dock of the"
+      }
+    },
+    "withoutmeta": {
+      "bar": "foo",
+      "enum": [
+        "baa",
+        "bad",
+        "bag",
+        "bah",
+        "bam",
+        "ban",
+        "bap",
+        "bas",
+        "bat",
+        "bay"
+      ]
+    }
+  }
+}


### PR DESCRIPTION
- test(markdown-builder): add test for enums
- fix(markdown-builder): guard against `enum` being not an array

fixes #458
