### PR TITLE
fix: fix typo in 'any of the following' text

### DIFF
--- a/examples/docs/typearrays-properties-string-or-number-null.md
+++ b/examples/docs/typearrays-properties-string-or-number-null.md
@@ -12,4 +12,4 @@ Types can be many things, even nothing at all.
 
 ## string-or-number-null Type
 
-any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))
+any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))

--- a/examples/docs/typearrays-properties-string-or-number.md
+++ b/examples/docs/typearrays-properties-string-or-number.md
@@ -12,4 +12,4 @@ Types can be many things
 
 ## string-or-number Type
 
-any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number.md))
+any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number.md))

--- a/examples/docs/typearrays.md
+++ b/examples/docs/typearrays.md
@@ -67,7 +67,7 @@ Types can be many things
 
 *   is optional
 
-*   Type: any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number.md))
+*   Type: any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number.md))
 
 *   cannot be null
 
@@ -75,7 +75,7 @@ Types can be many things
 
 ### string-or-number Type
 
-any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number.md))
+any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number.md))
 
 ## string-or-number-null
 
@@ -85,7 +85,7 @@ Types can be many things, even nothing at all.
 
 *   is optional
 
-*   Type: any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))
+*   Type: any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))
 
 *   can be null
 
@@ -93,4 +93,4 @@ Types can be many things, even nothing at all.
 
 ### string-or-number-null Type
 
-any of the folllowing: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))
+any of the following: `string` or `number` ([Details](typearrays-properties-string-or-number-null.md))

--- a/lib/locales/de.json
+++ b/lib/locales/de.json
@@ -73,7 +73,7 @@
     "and all following items may follow any schema": "und alle weiteren Bestandteile der Liste müssen keinem bestimmten Schema folgen",
     "and all following items must follow the schema: ": "und alle weiteren Bestandteile der Liste müssen diesem Schema folgen: ",
     "any of": "irgendeines",
-    "any of the folllowing: ": "irgendeines der folgenden Schemas: ",
+    "any of the following: ": "irgendeines der folgenden Schemas: ",
     "can be null": "darf null sein",
     "cannot be null": "darf nicht null sein",
     "check the specification": "Spezifikation ansehen",

--- a/lib/locales/en_US.json
+++ b/lib/locales/en_US.json
@@ -73,7 +73,7 @@
     "and all following items may follow any schema": "and all following items may follow any schema",
     "and all following items must follow the schema: ": "and all following items must follow the schema: ",
     "any of": "any of",
-    "any of the folllowing: ": "any of the folllowing: ",
+    "any of the following: ": "any of the following: ",
     "can be null": "can be null",
     "cannot be null": "cannot be null",
     "check the specification": "check the specification",

--- a/lib/locales/nl_NL.json
+++ b/lib/locales/nl_NL.json
@@ -73,7 +73,7 @@
     "and all following items may follow any schema": "en alle volgende items kunnen elk schema volgen:",
     "and all following items must follow the schema: ": "en alle volgende items moeten het schema volgen:",
     "any of": "een van",
-    "any of the folllowing: ": "een van de volgende:",
+    "any of the following: ": "een van de volgende:",
     "can be null": "kan null zijn",
     "cannot be null": "Kan niet null zijn",
     "check the specification": "controleer de specificatie",

--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -437,7 +437,7 @@ export default function build({
       } else if (singletype && firsttype && typeof firsttype === 'string') {
         return [inlineCode(firsttype + isarray)];
       } else if (!singletype) {
-        return [text(isarray ? i18n`an array of the following:` : i18n`any of the folllowing: `), ...flist(flat(realtypes.map((mytype, index) => [inlineCode(mytype || i18n`not defined`), text(index === realtypes.length - 1 ? '' : i18n` or `)])))];
+        return [text(isarray ? i18n`an array of the following:` : i18n`any of the following: `), ...flist(flat(realtypes.map((mytype, index) => [inlineCode(mytype || i18n`not defined`), text(index === realtypes.length - 1 ? '' : i18n` or `)])))];
       } else if (merged) {
         return [text(isarray ? 'an array of merged types' : i18n`merged type`)];
       }

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -253,7 +253,7 @@ describe('Testing Markdown Builder: types', () => {
 
   it('Multiple Typed Schema looks OK', () => {
     assertMarkdown(results.objectorarray)
-      .has('paragraph > text[value="any of the folllowing: "]');
+      .has('paragraph > text[value="any of the following: "]');
   });
 
   it('Undefined Schema looks OKish', () => {


### PR DESCRIPTION
Does not relate to an open issue (the `CONTRIBUTING.md` file says that I should use a `[trivial]` tag in my commit message, but it seems the last time anybody in this repo has done this was in 2018 in https://github.com/adobe/jsonschema2md/commit/55aa06991b5dc19042b4e5f0cada48343ec62540, so I'm not sure if this is still valid)

This issue was caught by https://www.npmjs.com/package/cspell, which was present in the the repo I was trying to add `jsonschema2md` too.

I've just done a simple find-and-replace everything in the repo, since running `npm run examples` seems to create a lot of changes that are unrelated to this change.

Should I modify my commit title to `fix(markdown-builder): fix typo in 'any of the following' text`? Or `fix(i18n): fix typo in 'any of the following' text`.