### PR TITLE
fix: 🐛 correct handle yaml example-format for default values

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -705,7 +705,14 @@ export default function build({
   }
 
   function makedefault(schema, level = 1) {
-    if (schema[keyword`default`]) {
+    if (schema[keyword`default`] && exampleFormat === 'yaml') {
+      return [
+        heading(level + 1, text(i18n`${simpletitle(schema)} Default Value`)),
+        paragraph(text(i18n`The default value is:`)),
+        paragraph(code('yaml', yaml.dump(schema[keyword`default`], undefined, 2))),
+      ];
+    }
+    if (schema[keyword`default`] && exampleFormat === 'json') {
       return [
         heading(level + 1, text(i18n`${simpletitle(schema)} Default Value`)),
         paragraph(text(i18n`The default value is:`)),


### PR DESCRIPTION
Render defaults as yaml when using --example-format yaml

✅ Closes: #246
