### PR TITLE
fix: support schema content with pathy `fileName`

### DIFF
--- a/lib/writeSchema.js
+++ b/lib/writeSchema.js
@@ -38,7 +38,7 @@ export default function writeSchema({ schemadir, origindir }) {
       const inputPath = schema[s.fullpath] || (origindir && path.join(origindir, fileName));
       let content = schema;
 
-      if (inputPath) {
+      if (inputPath && fs.existsSync(inputPath)) {
         content = fs.readJsonSync(inputPath);
         if (schema[s.meta] && schema[s.meta].description) {
           // copy description from external file

--- a/test/api.test.js
+++ b/test/api.test.js
@@ -88,6 +88,30 @@ describe('Testing Public API', () => {
     assert.strictEqual(result.markdown.length, 31);
   });
 
+  /**
+   * When running with no `outDir` and no `schemaOut`, links to JSON Schema
+   * should use `fullPath`, even if it can't be resolved.
+   */
+  it('Public API with non-existent schema path works', async () => {
+    const schemasFiles = await loadSchemas('readme-1');
+    const schemas = schemasFiles.map(({ fileName, fullPath }) => ({
+      fileName: path.join('/my-custom-path-to-schema', fileName),
+      // eslint-disable-next-line global-require, import/no-dynamic-require
+      content: fs.readJSONSync(fullPath),
+    }));
+
+    const result = jsonschema2md(schemas, {
+      // don't output anything
+      header: true,
+    });
+    assert.strictEqual(result.readme, undefined);
+    assert.strictEqual(result.schema.length, 3);
+    assert.strictEqual(result.markdown.length, 32);
+
+    assertMarkdown(result.markdown.find(({ fileName }) => fileName === 'simple.md').markdownAst)
+      .contains('[simple.schema.json](/my-custom-path-to-schema/simple.schema.json "open original schema")');
+  });
+
   it('Public API processes from single schema', async () => {
     const result = jsonschema2md(example, {
       includeReadme: true,


### PR DESCRIPTION
Prevent an `ENOENT` error when running `jsonschema2md` on a JSON Schema that doesn't exist on disk, yet has a pathy `fileName`.

Using a `fileName` that is a path is required to get working links to the `schema.json` file in the output Markdown.

### Current behavior

The `Public API with non-existent schema path works` test (added in this PR) currently fails with the following error.

```
  1) Testing Public API
       Public API with non-existent schema path works:
     Error: /my-custom-path-to-schema/abstract.schema.json: ENOENT: no such file or directory, open '/my-custom-path-to-schema/abstract.schema.json'
      at Object.openSync (node:fs:601:3)
      at Object.readFileSync (node:fs:469:35)
      at Object.readFileSync (node_modules/jsonfile/index.js:50:22)
      at file:///home/alois/Documents/jsonschema2md/lib/writeSchema.js:42:22
      at Array.map (<anonymous>)
      at file:///home/alois/Documents/jsonschema2md/lib/writeSchema.js:36:24
      at jsonschema2md (file:///home/alois/Documents/jsonschema2md/lib/index.js:153:5)
      at Context.<anonymous> (file:///home/alois/Documents/jsonschema2md/test/api.test.js:103:20)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
```

### Background

I'm trying to simplify some code in https://github.com/mermaid-js/mermaid/blob/b87f1f209843ed794d83bfece5669adf595bdabd/packages/mermaid/scripts/docs.mts#L393-L420 to use the official `import {jsonschema2md} from ...` API, since it currently uses a bunch of internals.

