### PR TITLE
build!: bump minimun Node.JS version to Node 16.18

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -10,10 +10,10 @@ jobs:
     if: "!contains(github.event.head_commit.message, '[skip ci]')"
     steps:
       - uses: actions/checkout@v3
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.18'
       - run: npm install
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"
       - run: npm test
@@ -26,10 +26,10 @@ jobs:
     steps:
       - run: git config --global core.autocrlf false
       - uses: actions/checkout@v3
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.18'
       - run: npm install
       - run: git config --global user.email "test@project-helix.io" && git config --global user.name "Test Build"
       - run: npm test
@@ -44,10 +44,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           persist-credentials: false
-      - name: Use Node.js 14.x
+      - name: Use Node.js 16.18
         uses: actions/setup-node@v3
         with:
-          node-version: '14.x'
+          node-version: '16.18'
       - run: npm install
       - run: npm run semantic-release
         env:

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ These tools have been introduced by Adobe to document Adobe's Experience Data Mo
 ## Requirements
 
 - `npm` version 3.10.8 or up
-- `node` v14 or up
+- `node` v16.18, v18, or v20 or up
 
 ## Example Output
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "unist-util-select": "5.0.0"
       },
       "engines": {
-        "node": ">= 14.0.0"
+        "node": "^16.18.0 || ^18.0.0 || >= 20.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "unist-util-select": "5.0.0"
   },
   "engines": {
-    "node": ">= 14.0.0"
+    "node": "^16.18.0 || ^18.0.0 || >= 20.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Bump the minimum version of Node.JS to Node v16.18. Node v14, v15, v17, v19 are all no longer being maintained, see https://github.com/nodejs/release#release-schedule

Additionally, PR https://github.com/adobe/jsonschema2md/pull/516 updated [mdast-util-to-string](https://togithub.com/syntax-tree/mdast-util-to-string) to [4.0.0](https://renovatebot.com/diffs/npm/mdast-util-to-string/3.2.0/4.0.0), [unist-util-inspect](https://togithub.com/syntax-tree/unist-util-inspect) to [8.0.0](https://renovatebot.com/diffs/npm/unist-util-inspect/7.0.2/8.0.0), and [unist-util-select](https://togithub.com/syntax-tree/unist-util-select) to [5.0.0](https://renovatebot.com/diffs/npm/unist-util-select/4.0.3/5.0.0), and all of these packages now require Node.JS v16 (at least according to their release notes, they still seem to run okay on Node.JS v14)

Node v16.18 was picked as the minimum required Node.JS version, since that's the most commonly available Node.JS version in OS package repos, see https://repology.org/project/nodejs/versions

**BREAKING CHANGE**: The minimum supported version of NodeJS is now 16.18, 18.x, or >= 20.x. NodeJS v14, v15, v17, and v19 are no longer supported.