### PR TITLE
Support TypeScript's `moduleResolution: "Node16"`

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -38,19 +38,19 @@ const info = logger.info.bind(logger);
 const error = logger.error.bind(logger);
 
 /**
- * @typedef {import("../types/api").JsonSchema} JsonSchema
+ * @typedef {import("../types/api.js").JsonSchema} JsonSchema
  */
 /**
- * @typedef {import("../types/api").SchemaList} SchemaList
+ * @typedef {import("../types/api.js").SchemaList} SchemaList
  */
 /**
- * @typedef {import("../types/api").SchemaContent} SchemaContent
+ * @typedef {import("../types/api.js").SchemaContent} SchemaContent
  */
 /**
- * @typedef {import("../types/api").SchemaFiles} SchemaFiles
+ * @typedef {import("../types/api.js").SchemaFiles} SchemaFiles
  */
 /**
- * @typedef {import("../types/api").GeneratedOutput} GeneratedOutput
+ * @typedef {import("../types/api.js").GeneratedOutput} GeneratedOutput
  */
 
 /**

--- a/lib/symbols.js
+++ b/lib/symbols.js
@@ -11,7 +11,7 @@
  */
 
 /**
- * @typedef {import("../types/api").UniqueSymbols} UniqueSymbols
+ * @typedef {import("../types/api.js").UniqueSymbols} UniqueSymbols
  */
 
 export const filename = Symbol('filename');

--- a/lib/writeMarkdown.js
+++ b/lib/writeMarkdown.js
@@ -18,13 +18,13 @@ import fs from 'fs-extra';
 import yaml from 'js-yaml';
 
 /**
- * @typedef {import("../types/api").MarkdownAst} MarkdownAst
+ * @typedef {import("../types/api.js").MarkdownAst} MarkdownAst
  */
 /**
- * @typedef {import("../types/api").MarkdownContent} MarkdownContent
+ * @typedef {import("../types/api.js").MarkdownContent} MarkdownContent
  */
 /**
- * @typedef {import("../types/api").ReadmeContent} ReadmeContent
+ * @typedef {import("../types/api.js").ReadmeContent} ReadmeContent
  */
 /**
  * @typedef {{ [name: string]: MarkdownAst }} MarkdownAstFiles

--- a/lib/writeSchema.js
+++ b/lib/writeSchema.js
@@ -14,10 +14,10 @@ import path from 'path';
 import s from './symbols.js';
 
 /**
- * @typedef {import("../types/api").ExtendedJsonSchema} ExtendedJsonSchema
+ * @typedef {import("../types/api.js").ExtendedJsonSchema} ExtendedJsonSchema
  */
 /**
- * @typedef {import("../types/api").SchemaContent} SchemaContent
+ * @typedef {import("../types/api.js").SchemaContent} SchemaContent
  */
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -6534,9 +6534,9 @@
       }
     },
     "node_modules/micromark-extension-gfm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.1.tgz",
-      "integrity": "sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
       "dependencies": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
         "micromark-extension-gfm-footnote": "^1.0.0",
@@ -18214,9 +18214,9 @@
       }
     },
     "micromark-extension-gfm": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.1.tgz",
-      "integrity": "sha512-p2sGjajLa0iYiGQdT0oelahRYtMWvLjy8J9LOCxzIQsllMCGLbsLW+Nc+N4vi02jcRJvedVJ68cjelKIO6bpDA==",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
       "requires": {
         "micromark-extension-gfm-autolink-literal": "^1.0.0",
         "micromark-extension-gfm-footnote": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -8,6 +8,33 @@
     "jsonschema2md": "./cli.js"
   },
   "type": "module",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    },
+    "./lib/*.js": {
+      "import": {
+        "types": "./types/*.d.ts",
+        "default": "./lib/*.js"
+      }
+    },
+    "./lib/*": {
+      "import": {
+        "types": "./types/*.d.ts",
+        "default": "./lib/*.js"
+      }
+    },
+    "./lib/index": {
+      "import": {
+        "types": "./types/index.d.ts",
+        "default": "./lib/index.js"
+      }
+    },
+    "./package.json": "./package.json"
+  },
   "scripts": {
     "semantic-release": "npm run emit-types && npx semantic-release",
     "commit": "git-cz",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "es6",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "allowJs": true,
     "declaration": true,
     "emitDeclarationOnly": true,

--- a/types/formatInfo.d.ts
+++ b/types/formatInfo.d.ts
@@ -1,8 +1,8 @@
 export default function formatmeta(schema: any): {
-    longcomment: import("mdast").Root;
+    longcomment: import("remark-stringify/node_modules/@types/mdast").Root;
     shortcomment: any;
     comment: string;
-    longdescription: import("mdast").Root;
+    longdescription: import("remark-stringify/node_modules/@types/mdast").Root;
     shortdescription: any;
     description: any;
     abstract: boolean;

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,17 +1,17 @@
 /**
- * @typedef {import("../types/api").JsonSchema} JsonSchema
+ * @typedef {import("../types/api.js").JsonSchema} JsonSchema
  */
 /**
- * @typedef {import("../types/api").SchemaList} SchemaList
+ * @typedef {import("../types/api.js").SchemaList} SchemaList
  */
 /**
- * @typedef {import("../types/api").SchemaContent} SchemaContent
+ * @typedef {import("../types/api.js").SchemaContent} SchemaContent
  */
 /**
- * @typedef {import("../types/api").SchemaFiles} SchemaFiles
+ * @typedef {import("../types/api.js").SchemaFiles} SchemaFiles
  */
 /**
- * @typedef {import("../types/api").GeneratedOutput} GeneratedOutput
+ * @typedef {import("../types/api.js").GeneratedOutput} GeneratedOutput
  */
 /**
  * Public API for jsonschema2md that can be used to turn JSON Schema files
@@ -42,7 +42,7 @@
  * skip in markdown.
  * @returns {GeneratedOutput} List of raw markdown that were generated from input schema.
  */
-export function jsonschema2md(schema: JsonSchema | import("../types/api").SchemaFiles, options: {
+export function jsonschema2md(schema: JsonSchema | import("../types/api.js").SchemaFiles, options: {
     schemaPath?: string;
     outDir?: string;
     metadata?: {
@@ -68,8 +68,8 @@ export function jsonschema2md(schema: JsonSchema | import("../types/api").Schema
 export function main(args: {
     [key: string]: unknown;
 }): Promise<number>;
-export type JsonSchema = import("../types/api").JsonSchema;
-export type SchemaList = import("../types/api").SchemaList;
-export type SchemaContent = import("../types/api").SchemaContent;
-export type SchemaFiles = import("../types/api").SchemaFiles;
-export type GeneratedOutput = import("../types/api").GeneratedOutput;
+export type JsonSchema = import("../types/api.js").JsonSchema;
+export type SchemaList = import("../types/api.js").SchemaList;
+export type SchemaContent = import("../types/api.js").SchemaContent;
+export type SchemaFiles = import("../types/api.js").SchemaFiles;
+export type GeneratedOutput = import("../types/api.js").GeneratedOutput;

--- a/types/symbols.d.ts
+++ b/types/symbols.d.ts
@@ -1,10 +1,10 @@
 /**
- * @typedef {import("../types/api").UniqueSymbols} UniqueSymbols
+ * @typedef {import("../types/api.js").UniqueSymbols} UniqueSymbols
  */
 export const filename: unique symbol;
 export const fullpath: unique symbol;
 export default symbols;
-export type UniqueSymbols = import("../types/api").UniqueSymbols;
+export type UniqueSymbols = import("../types/api.js").UniqueSymbols;
 /**
  * @type {UniqueSymbols}
  * */

--- a/types/writeMarkdown.d.ts
+++ b/types/writeMarkdown.d.ts
@@ -1,11 +1,11 @@
 /**
- * @typedef {import("../types/api").MarkdownAst} MarkdownAst
+ * @typedef {import("../types/api.js").MarkdownAst} MarkdownAst
  */
 /**
- * @typedef {import("../types/api").MarkdownContent} MarkdownContent
+ * @typedef {import("../types/api.js").MarkdownContent} MarkdownContent
  */
 /**
- * @typedef {import("../types/api").ReadmeContent} ReadmeContent
+ * @typedef {import("../types/api.js").ReadmeContent} ReadmeContent
  */
 /**
  * @typedef {{ [name: string]: MarkdownAst }} MarkdownAstFiles
@@ -48,9 +48,9 @@ export function writereadme({ out, error, info, meta, }: {
         [key: string]: string;
     };
 }): (markdownAst: MarkdownAst) => ReadmeContent;
-export type MarkdownAst = import("../types/api").MarkdownAst;
-export type MarkdownContent = import("../types/api").MarkdownContent;
-export type ReadmeContent = import("../types/api").ReadmeContent;
+export type MarkdownAst = import("../types/api.js").MarkdownAst;
+export type MarkdownContent = import("../types/api.js").MarkdownContent;
+export type ReadmeContent = import("../types/api.js").ReadmeContent;
 export type MarkdownAstFiles = {
     [name: string]: import("mdast").Root;
 };

--- a/types/writeSchema.d.ts
+++ b/types/writeSchema.d.ts
@@ -1,8 +1,8 @@
 /**
- * @typedef {import("../types/api").ExtendedJsonSchema} ExtendedJsonSchema
+ * @typedef {import("../types/api.js").ExtendedJsonSchema} ExtendedJsonSchema
  */
 /**
- * @typedef {import("../types/api").SchemaContent} SchemaContent
+ * @typedef {import("../types/api.js").SchemaContent} SchemaContent
  */
 /**
  * Write the JSON Schemas to filesystem or an object
@@ -15,5 +15,5 @@ export default function writeSchema({ schemadir, origindir }: {
     schemadir?: string;
     origindir?: string;
 }): (schemas: ExtendedJsonSchema[]) => SchemaContent[];
-export type ExtendedJsonSchema = import("../types/api").ExtendedJsonSchema;
-export type SchemaContent = import("../types/api").SchemaContent;
+export type ExtendedJsonSchema = import("../types/api.js").ExtendedJsonSchema;
+export type SchemaContent = import("../types/api.js").SchemaContent;


### PR DESCRIPTION
Add support for TypeScript's `moduleResolution: "Node16"`.

There's more information about what this this entails in https://www.typescriptlang.org/docs/handbook/esm-node.html, but essentially, it lets TypeScript check that all ESM imports match what Node.JS can import.

However, TypeScript will no longer look at the `"types"`/`"typing"` field in your `package.json` file. Instead, they except entries in the [`"exports"` field in `package.json`](https://nodejs.org/api/packages.html#packages_exports).

In order to avoid breaking backwards compatibility with newer versions of Node.JS, that may have use something like `import * from "@adobe/jsonschema2md/lib/config"`, we need to explicitly list every single import path that people may have used.

---

### Before

Using https://arethetypeswrong.github.io/?p=%40adobe%2Fjsonschema2md%407.1.5, we can see that the `node16` types are currently broken for `@adobe/jsonschema2md` v7.1.5:

![Screenshot of @adobe/jsonschema2md v7.1.5 result from https://arethetypeswrong.github.io](https://github.com/adobe/jsonschema2md/assets/19716675/dc3df00f-4d81-4bb5-8949-dd65fc526aba)

### After

Run `npm pack`, and upload the file to https://arethetypeswrong.github.io/

![Screenshot of @adobe/jsonschema2md from this result from https://arethetypeswrong.github.io, when uploaded a `npm pack` from this PR](https://github.com/adobe/jsonschema2md/assets/19716675/d43556d8-5bc3-49b1-a491-c6f494da5cd1)
