### PR TITLE
fix(markdownBuilder): boolean defaults didn't render when the default was false

### DIFF
--- a/lib/markdownBuilder.js
+++ b/lib/markdownBuilder.js
@@ -705,7 +705,7 @@ export default function build({
   }
 
   function makedefault(schema, level = 1) {
-    if (schema[keyword`default`]) {
+    if (schema[keyword`default`] !== undefined) {
       return [
         heading(level + 1, text(i18n`${simpletitle(schema)} Default Value`)),
         paragraph(text(i18n`The default value is:`)),

--- a/test/fixtures/boolean-defaults/boolean-defaults.schema.json
+++ b/test/fixtures/boolean-defaults/boolean-defaults.schema.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://example.com/schemas/boolean-defaults",
+  "title": "Boolean Defaults Test Schema",
+  "description": "Testing boolean default value rendering in markdown generation",
+  "type": "object",
+  "properties": {
+    "enabledByDefault": {
+      "type": "boolean",
+      "default": true,
+      "description": "A boolean property with a default value of true"
+    },
+    "disabledByDefault": {
+      "type": "boolean", 
+      "default": false,
+      "description": "A boolean property with a default value of false"
+    },
+    "noDefault": {
+      "type": "boolean",
+      "description": "A boolean property with no default value"
+    }
+  }
+}

--- a/test/markdownBuilder.test.js
+++ b/test/markdownBuilder.test.js
@@ -439,3 +439,32 @@ describe('Testing Markdown Builder: Skip properties', () => {
       .doesNotContain('-   defined in: [Complete JSON Schema]');
   });
 });
+
+describe('Testing Markdown Builder: boolean defaults', () => {
+  let results;
+
+  before(async () => {
+    const schemas = await traverseSchemas('boolean-defaults');
+    const builder = build({ header: false });
+    results = builder(schemas);
+  });
+
+  it('Boolean true default renders correctly', () => {
+    assertMarkdown(results['boolean-defaults'])
+      .contains('enabledByDefault Default Value')
+      .contains('The default value is:')
+      .contains('true');
+  });
+
+  it('Boolean false default renders correctly', () => {
+    assertMarkdown(results['boolean-defaults'])
+      .contains('disabledByDefault Default Value')
+      .contains('The default value is:')
+      .contains('false');
+  });
+
+  it('Boolean with no default does not render default section', () => {
+    assertMarkdown(results['boolean-defaults'])
+      .doesNotContain('noDefault Default Value');
+  });
+});


### PR DESCRIPTION
The `markdownBuilder` didn't render property defaults for `boolean` properties when the default was `false` due to a truthy check instead of `!== undefined`.

Added a regression test & fixed the issue.

I have signed the Adobe CLA; you can find it associated with this GitHub username.