### PR TITLE
fix: add missing GitHub Actions permissions for semantic-release

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -42,6 +42,9 @@ jobs:
     if: github.ref == 'refs/heads/main'
     needs: [build, build_win]
     permissions:
+      contents: write
+      issues: write
+      pull-requests: write
       id-token: write # needed for npm trusted publishers with OIDC
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Added missing GitHub Actions permissions to the release job to fix semantic-release failures
- The release workflow was failing with `Permission to adobe/jsonschema2md.git denied to github-actions[bot]`
- Added `contents: write`, `issues: write`, and `pull-requests: write` permissions

## Root Cause
The recent update to semantic-release v25 and Node 24.x (PR #673) added OIDC support with `id-token: write` permission, but didn't include the other necessary permissions for semantic-release to function properly. Semantic-release needs:
- `contents: write` - to push version tags to the repository
- `issues: write` - to comment on issues related to releases
- `pull-requests: write` - to comment on PRs included in releases

## Test Plan
- [x] Verify the workflow file changes are correct
- [ ] Merge this PR and confirm the next release workflow succeeds
- [ ] Verify semantic-release can push tags and create releases

🤖 Generated with [Claude Code](https://claude.com/claude-code)